### PR TITLE
[WIP]feat: 新的游戏计时器

### DIFF
--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer.meta
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c4803ba4a8280b049848fbaba10b9350
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/DefaultMusicGameTimer.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/DefaultMusicGameTimer.cs
@@ -1,0 +1,175 @@
+using System;
+
+namespace CyanStars.Gameplay.MusicGame
+{
+    public class DefaultMusicGameTimer : IMusicGameTimer
+    {
+        private const int TimerCount = 2;
+
+        private IMusicGameTimer[] timers;
+        private TimerEvaluateData[] lastEvaluateDatas;
+        private TimerEvaluateData[] tempEvaluateDatas;
+        private int[] evaluateDataKeepCounts;
+
+        public double Time { get; private set; }
+        public int Milliseconds { get; private set; }
+        public MusicGameTimerState State { get; private set; }
+
+        public DefaultMusicGameTimer()
+        {
+            timers = new IMusicGameTimer[TimerCount]
+            {
+                new DspTimer(true),
+                new StopWatchTimer()
+            };
+
+            lastEvaluateDatas = new TimerEvaluateData[TimerCount];
+            tempEvaluateDatas = new TimerEvaluateData[TimerCount];
+            evaluateDataKeepCounts = new int[TimerCount];
+        }
+
+        public void Reset()
+        {
+            if (State == MusicGameTimerState.Running)
+                throw new InvalidOperationException("Can't reset game timer when it's running.");
+
+            Reset_Internal();
+        }
+
+        public bool Start(double delay = 0)
+        {
+            if (State == MusicGameTimerState.Running)
+                return false;
+
+            for (int i = 0; i < TimerCount; i++)
+            {
+                timers[i].Start(delay);
+            }
+
+            State = MusicGameTimerState.Running;
+            return true;
+        }
+
+        public bool Pause()
+        {
+            if (State != MusicGameTimerState.Running)
+                return false;
+
+            for (int i = 0; i < TimerCount; i++)
+            {
+                timers[i].Pause();
+            }
+
+            State = MusicGameTimerState.Pause;
+            return true;
+        }
+
+        public void Stop()
+        {
+            if (State == MusicGameTimerState.None)
+                return;
+
+            for (int i = 0; i < TimerCount; i++)
+            {
+                timers[i].Stop();
+            }
+
+            Reset_Internal();
+        }
+
+        public TimerEvaluateData Evaluate()
+        {
+            if (State == MusicGameTimerState.None)
+                return default;
+
+            if (State == MusicGameTimerState.Pause || !UpdateAllTimer())
+            {
+                return new TimerEvaluateData
+                {
+                    TotalSeconds = Time, LastTotalSeconds = Time,
+                    TotalMilliseconds = Milliseconds, LastTotalMilliseconds = Milliseconds
+                };
+            }
+
+            int timeCount = 0;
+            for (int i = 0; i < TimerCount; i++)
+            {
+                timeCount += evaluateDataKeepCounts[i];
+            }
+
+            double lastTime = Time;
+            int lastMilliseconds = Milliseconds;
+
+            double time = 0;
+            int milliseconds = 0;
+
+            for (int i = 0; i < TimerCount; i++)
+            {
+                double rate = 1.0 - (double)evaluateDataKeepCounts[i] / timeCount;
+                // UnityEngine.Debug.Log($"Timer[{i}] keepCount: {evaluateDataKeepCounts[i]}, rate: {rate}.");
+                time += tempEvaluateDatas[i].TotalSeconds * rate;
+                milliseconds += (int)(tempEvaluateDatas[i].TotalMilliseconds * rate);
+            }
+
+            Time = time;
+            Milliseconds = milliseconds;
+
+            for (int i = 0; i < TimerCount; i++)
+            {
+                lastEvaluateDatas[i] = tempEvaluateDatas[i];
+            }
+
+            return new TimerEvaluateData
+            {
+                TotalSeconds = time, LastTotalSeconds = lastTime,
+                TotalMilliseconds = milliseconds, LastTotalMilliseconds = lastMilliseconds
+            };
+        }
+
+        /// <returns> Is any timer value has been valid update </returns>
+        private bool UpdateAllTimer()
+        {
+            for (int i = 0; i < TimerCount; i++)
+            {
+                tempEvaluateDatas[i] = timers[i].Evaluate();
+                // UnityEngine.Debug.Log($"Timer[{i}]: {tempEvaluateDatas[i].TotalSeconds}.");
+            }
+
+            bool isAnyUpdated = false;
+            for (int i = 0; i < TimerCount; i++)
+            {
+                if (IsModified(tempEvaluateDatas[i], lastEvaluateDatas[i]))
+                {
+                    evaluateDataKeepCounts[i] = 1;
+                    isAnyUpdated = true;
+                }
+                else
+                {
+                    evaluateDataKeepCounts[i]++;
+                }
+            }
+
+            return isAnyUpdated;
+        }
+
+        private bool IsModified(TimerEvaluateData newData, TimerEvaluateData oldData)
+        {
+            return newData.TotalMilliseconds > oldData.TotalMilliseconds;
+        }
+
+        private void Reset_Internal()
+        {
+            for (int i = 0; i < TimerCount; i++)
+            {
+                timers[i].Reset();
+                lastEvaluateDatas[i] = default;
+                tempEvaluateDatas[i] = default;
+                evaluateDataKeepCounts[i] = 0;
+            }
+
+            Time = 0;
+            Milliseconds = 0;
+            State = MusicGameTimerState.None;
+        }
+    }
+}

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/DefaultMusicGameTimer.cs.meta
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/DefaultMusicGameTimer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 84e762902f3654946b5a1504367f6a15
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/DspTimer.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/DspTimer.cs
@@ -1,0 +1,123 @@
+using System;
+using UnityEngine;
+
+namespace CyanStars.Gameplay.MusicGame
+{
+    public class DspTimer : IMusicGameTimer
+    {
+        private readonly bool UseGameTimeCompensation;
+
+        private double delay;
+
+        private double lastDspTime;
+        private double pauseDspTime;
+
+        private double finalDspTime;
+        private double nonFixedTime;
+
+        public double Time { get; private set; }
+        public int Milliseconds => (int)(Time * 1000);
+
+        public MusicGameTimerState State { get; private set; }
+
+        public DspTimer(bool useGameTimeCompensation = false)
+        {
+            UseGameTimeCompensation = useGameTimeCompensation;
+        }
+
+        public bool Pause()
+        {
+            if (State != MusicGameTimerState.Running)
+                return false;
+
+            pauseDspTime = AudioSettings.dspTime;
+            State = MusicGameTimerState.Pause;
+            return true;
+        }
+
+        public void Reset()
+        {
+            if (State == MusicGameTimerState.Running)
+                throw new InvalidOperationException("Can't reset game timer when it's running.");
+
+            delay = 0;
+            lastDspTime = 0;
+            pauseDspTime = 0;
+            finalDspTime = 0;
+            nonFixedTime = 0;
+            Time = 0;
+            State = MusicGameTimerState.None;
+        }
+
+        public void Stop()
+        {
+            Pause();
+            Reset();
+        }
+
+        public bool Start(double delay = 0)
+        {
+            if (State == MusicGameTimerState.None)
+            {
+                lastDspTime = AudioSettings.dspTime;
+                this.delay = delay;
+            }
+            else if (State == MusicGameTimerState.Pause)
+            {
+                this.delay += delay;
+                double dspTime = AudioSettings.dspTime;
+                double dt = pauseDspTime - lastDspTime;
+                lastDspTime = dspTime;
+                finalDspTime += dt;
+            }
+            else
+            {
+                return false;
+            }
+
+            State = MusicGameTimerState.Running;
+            return true;
+        }
+
+        public TimerEvaluateData Evaluate()
+        {
+            if (State == MusicGameTimerState.None)
+                return default;
+
+            double dspTime = AudioSettings.dspTime;
+            bool isDspTimeChanged = Math.Abs(dspTime - lastDspTime) > 0.00001;
+            if (State == MusicGameTimerState.Pause || (!UseGameTimeCompensation && !isDspTimeChanged))
+            {
+                double time = Time;
+                int ms = Milliseconds;
+                return new TimerEvaluateData
+                {
+                    TotalSeconds = time, LastTotalSeconds = time,
+                    TotalMilliseconds = ms, LastTotalMilliseconds = ms
+                };
+            }
+
+            double lastTime = Time;
+            int lastMilliseconds = Milliseconds;
+
+            if (isDspTimeChanged)
+            {
+                finalDspTime += dspTime - lastDspTime;
+                nonFixedTime = finalDspTime;
+                lastDspTime = dspTime;
+            }
+            else
+            {
+                nonFixedTime += UnityEngine.Time.unscaledDeltaTime;
+            }
+
+            Time = nonFixedTime - delay;
+
+            return new TimerEvaluateData
+            {
+                TotalSeconds = Time, LastTotalSeconds = lastTime,
+                TotalMilliseconds = Milliseconds, LastTotalMilliseconds = lastMilliseconds
+            };
+        }
+    }
+}

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/DspTimer.cs.meta
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/DspTimer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4b2ff5e983cdd544c9ceec5d6edab05a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/GameTimeSpan.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/GameTimeSpan.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace CyanStars.Gameplay.MusicGame
+{
+    public readonly struct GameTimeSpan
+    {
+        public readonly double TotalSeconds;
+        public readonly int TotalMilliseconds;
+
+        internal GameTimeSpan(double seconds, int milliseconds)
+        {
+            TotalSeconds = seconds;
+            TotalMilliseconds = milliseconds;
+        }
+
+        public static GameTimeSpan FromSeconds(double value)
+        {
+            return new GameTimeSpan(value, (int)(value * 1000));
+        }
+
+        public static GameTimeSpan FromMilliseconds(int value)
+        {
+            return new GameTimeSpan(value / 1000.0, value);
+        }
+
+        public static GameTimeSpan FromTimeSpan(TimeSpan value)
+        {
+            return new GameTimeSpan(value.TotalSeconds, (int)value.TotalMilliseconds);
+        }
+
+        public static explicit operator TimeSpan(GameTimeSpan self)
+        {
+            return TimeSpan.FromSeconds(self.TotalSeconds);
+        }
+    }
+
+    public static class GameTimeSpanExtensions
+    {
+        public static TimeSpan ToTimeSpan(this GameTimeSpan self)
+        {
+            return TimeSpan.FromSeconds(self.TotalSeconds);
+        }
+    }
+}

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/GameTimeSpan.cs.meta
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/GameTimeSpan.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d44ade8c766be944ebced38c460ea290
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/IMusicGameTimer.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/IMusicGameTimer.cs
@@ -1,0 +1,15 @@
+namespace CyanStars.Gameplay.MusicGame
+{
+    public interface IMusicGameTimer
+    {
+        double Time { get; }
+        int Milliseconds { get; }
+        MusicGameTimerState State { get; }
+
+        void Reset();
+        bool Start(double delay = 0);
+        bool Pause();
+        void Stop();
+        TimerEvaluateData Evaluate();
+    }
+}

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/IMusicGameTimer.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/IMusicGameTimer.cs
@@ -2,14 +2,14 @@ namespace CyanStars.Gameplay.MusicGame
 {
     public interface IMusicGameTimer
     {
-        double Time { get; }
-        int Milliseconds { get; }
+        GameTimeSpan Time { get; }
         MusicGameTimerState State { get; }
 
         void Reset();
-        bool Start(double delay = 0);
-        bool Pause();
+        bool Start(MusicGameTimeData data, double delay = 0);
+        bool Pause(MusicGameTimeData data);
+        bool UnPause(MusicGameTimeData data);
         void Stop();
-        TimerEvaluateData Evaluate();
+        TimerEvaluateData Evaluate(MusicGameTimeData data);
     }
 }

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/IMusicGameTimer.cs.meta
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/IMusicGameTimer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4b63eff51fb95ce4fa2e050357c4cbca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/MusicGameTimeData.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/MusicGameTimeData.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+namespace CyanStars.Gameplay.MusicGame
+{
+    public readonly struct MusicGameTimeData
+    {
+        public readonly double RealtimeSinceStartup;
+        public readonly double UnscaledDeltaTime;
+
+        private MusicGameTimeData(double realtimeSinceStartup, double unscaledDeltaTime)
+        {
+            RealtimeSinceStartup = realtimeSinceStartup;
+            UnscaledDeltaTime = unscaledDeltaTime;
+        }
+
+        public static MusicGameTimeData Create()
+        {
+            return new MusicGameTimeData(Time.realtimeSinceStartupAsDouble, Time.unscaledDeltaTime);
+        }
+    }
+}

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/MusicGameTimeData.cs.meta
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/MusicGameTimeData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6434de764a122b642a5adce983de5c71
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/MusicGameTimerState.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/MusicGameTimerState.cs
@@ -1,0 +1,9 @@
+namespace CyanStars.Gameplay.MusicGame
+{
+    public enum MusicGameTimerState
+    {
+        None,
+        Running,
+        Pause
+    }
+}

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/MusicGameTimerState.cs.meta
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/MusicGameTimerState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7ddfbe8f9fb2d05458857be83afa5002
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/RealtimeSliceStartupTimer.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/RealtimeSliceStartupTimer.cs
@@ -1,0 +1,105 @@
+using System;
+
+namespace CyanStars.Gameplay.MusicGame
+{
+    public class RealtimeSliceStartupTimer : IMusicGameTimer
+    {
+        private double delay;
+
+        private double startRealtime;
+        private double lastPauseRealtime;
+        private double lastEvaluationRealtime;
+        private double totalPauseTime;
+
+        public GameTimeSpan Time { get; private set; }
+
+        public MusicGameTimerState State { get; private set; }
+
+        public RealtimeSliceStartupTimer()
+        {
+            Reset();
+        }
+
+        public bool Pause(MusicGameTimeData data)
+        {
+            if (State != MusicGameTimerState.Running)
+                return false;
+
+            lastPauseRealtime = data.RealtimeSinceStartup;
+            State = MusicGameTimerState.Pause;
+            return true;
+        }
+
+        public bool UnPause(MusicGameTimeData data)
+        {
+            if (State != MusicGameTimerState.Pause)
+                return false;
+
+            totalPauseTime += data.RealtimeSinceStartup - lastPauseRealtime;
+            lastPauseRealtime = -double.NaN;
+            State = MusicGameTimerState.Running;
+            return true;
+        }
+
+        public void Reset()
+        {
+            if (State == MusicGameTimerState.Running)
+                throw new InvalidOperationException("Can't reset game timer when it's running.");
+
+            startRealtime = -double.NaN;
+            lastPauseRealtime = -double.NaN;
+            lastEvaluationRealtime = -double.NaN;
+            delay = 0;
+            totalPauseTime = 0;
+            Time = default;
+            State = MusicGameTimerState.None;
+        }
+
+        public void Stop()
+        {
+            State = MusicGameTimerState.None;
+            Reset();
+        }
+
+        public bool Start(MusicGameTimeData data, double delay = 0)
+        {
+            if (State != MusicGameTimerState.None)
+                return false;
+
+            startRealtime = data.RealtimeSinceStartup;
+            lastEvaluationRealtime = data.RealtimeSinceStartup;
+            totalPauseTime = 0;
+            this.delay = delay;
+            State = MusicGameTimerState.Running;
+            return true;
+        }
+
+        public TimerEvaluateData Evaluate(MusicGameTimeData data)
+        {
+            if (State == MusicGameTimerState.None)
+                return default;
+
+            bool isRealtimeChanged = data.RealtimeSinceStartup - lastEvaluationRealtime > 0.00001;
+            if (State == MusicGameTimerState.Pause || !isRealtimeChanged)
+            {
+                return new TimerEvaluateData
+                {
+                    Elapsed = Time,
+                    LastElapsed = Time,
+                };
+            }
+
+            var lastTime = Time;
+
+            lastEvaluationRealtime = data.RealtimeSinceStartup;
+            var newTime = GameTimeSpan.FromSeconds(data.RealtimeSinceStartup - startRealtime - totalPauseTime - delay);
+            Time = newTime;
+
+            return new TimerEvaluateData
+            {
+                Elapsed = newTime,
+                LastElapsed = lastTime,
+            };
+        }
+    }
+}

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/RealtimeSliceStartupTimer.cs.meta
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/RealtimeSliceStartupTimer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1fbafb14972f7ca4d8aa3aeb4f50e5d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/StopWatchTimer.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/StopWatchTimer.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Diagnostics;
+
+namespace CyanStars.Gameplay.MusicGame
+{
+    public class StopWatchTimer : IMusicGameTimer
+    {
+        private Stopwatch sw;
+
+        public double Time { get; private set; }
+        public int Milliseconds { get; private set; }
+
+        private double delay;
+        private int millisecondsDelay;
+
+        public MusicGameTimerState State
+        {
+            get
+            {
+                if (sw.IsRunning)
+                    return MusicGameTimerState.Running;
+                else if (Time > 0)
+                    return MusicGameTimerState.Pause;
+                else
+                    return MusicGameTimerState.None;
+            }
+        }
+
+        public StopWatchTimer()
+        {
+            sw = new Stopwatch();
+        }
+
+        public void Reset()
+        {
+            if (State == MusicGameTimerState.Running)
+                throw new InvalidOperationException("Can't reset game timer when it's running.");
+
+            sw.Reset();
+            Time = 0;
+            Milliseconds = 0;
+            delay = 0;
+            millisecondsDelay = 0;
+        }
+
+        public bool Start(double delay = 0)
+        {
+            if (!sw.IsRunning)
+            {
+                this.delay += delay;
+                this.millisecondsDelay = (int)(this.delay * 1000);
+                sw.Start();
+                return true;
+            }
+            return false;
+        }
+
+        public bool Pause()
+        {
+            bool ret = sw.IsRunning;
+            sw.Stop();
+            return ret;
+        }
+
+        public void Stop()
+        {
+            Pause();
+            Reset();
+        }
+
+        public TimerEvaluateData Evaluate()
+        {
+            var state = State;
+            if (state == MusicGameTimerState.None)
+                return default;
+
+            double time;
+            double lastTime;
+            int milliseconds;
+            int lastMilliseconds;
+
+            if (state == MusicGameTimerState.Pause || (int)sw.ElapsedMilliseconds - Milliseconds < 8)
+            {
+                time = Time - delay;
+                milliseconds = Milliseconds - millisecondsDelay;
+                lastTime = time;
+                lastMilliseconds = milliseconds;
+            }
+            else
+            {
+                lastTime = Time;
+                lastMilliseconds = Milliseconds;
+
+                var elapsed = sw.Elapsed;
+                Time = elapsed.TotalSeconds;
+                Milliseconds = (int)elapsed.TotalMilliseconds;
+
+                time = Time - delay;
+                milliseconds = Milliseconds - millisecondsDelay;
+            }
+
+            return new TimerEvaluateData
+            {
+                TotalSeconds = time, LastTotalSeconds = lastTime,
+                TotalMilliseconds = milliseconds, LastTotalMilliseconds = lastMilliseconds
+            };
+        }
+    }
+}

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/StopWatchTimer.cs.meta
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/StopWatchTimer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e6f28f77f32eb1a44bd7f01c4b3fbba6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/TimerEvaluateData.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/TimerEvaluateData.cs
@@ -1,0 +1,10 @@
+namespace CyanStars.Gameplay.MusicGame
+{
+    public struct TimerEvaluateData
+    {
+        public double TotalSeconds;
+        public double LastTotalSeconds;
+        public int TotalMilliseconds;
+        public int LastTotalMilliseconds;
+    }
+}

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/TimerEvaluateData.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/TimerEvaluateData.cs
@@ -2,9 +2,7 @@ namespace CyanStars.Gameplay.MusicGame
 {
     public struct TimerEvaluateData
     {
-        public double TotalSeconds;
-        public double LastTotalSeconds;
-        public int TotalMilliseconds;
-        public int LastTotalMilliseconds;
+        public GameTimeSpan Elapsed;
+        public GameTimeSpan LastElapsed;
     }
 }

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/TimerEvaluateData.cs.meta
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Timer/TimerEvaluateData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0a5a44d1efb3ac24fb8b44dbb3d5b0fb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
目前我们直接使用 AudioSource.time(和 dsp time 同步更新) 来作为音游的更新参考时间，这在 windows 和一般用例的 android 上工作得还算正常，但在 android + bluetooth 时可以观察到总是具有 6-8 帧的停顿

这个 PR 引入了一系列不与 dsp time 强绑定的独立计时器，但还未经过充分测试

引入的 Timer：
- **StopWatchTimer** : 基于 StopWatch 的计时器，在硬件高精度计时器可用时精度非常高，但上层 API 对它的控制粒度不够细，可能会随着每次暂停逐渐偏移
- **RealtimeSliceStartupTimer** : 和 StopWatch 类似，但是使用 Unity 提供的 API，这个 API 总是可以方便的获取，理论上不会在暂停时产生偏移 (或不可接受的偏移)
- **DspTimer** : 使用 dsp time，但是可以使用 delta time 或 realtime 来补偿 dsp time 的长时间停顿，还不清楚在多次暂停后的表现如何
- **DefaultMusicGameTime** : 综合多个 Timer 的结果取按比例取值，大部分时候只是单纯的取平均值

其他相关更改：
音乐现在不再从 MusicTrack 播放，而是由 MusicGameProcedure 直接安排播放，以精确的控制播放时间  
音乐总是延迟 1s 左右播放 ，在 android + bluetooth 上可能受到 dsp time 停顿的影响而延迟 800ms - 900ms，延迟可调

Fixes:
部分修复 #200

Edit:
note: 经过实际环境测试，多次暂停产生的偏移几乎不可接受，需要进一步确认问题发生的原因