### PR TITLE
fix: 修复key与hold的显示问题

### DIFF
--- a/Cyan-Stars/Assets/BundleRes/Prefabs/Notes/Hold.prefab
+++ b/Cyan-Stars/Assets/BundleRes/Prefabs/Notes/Hold.prefab
@@ -110,6 +110,8 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 6431394066461902562}
+  - {fileID: 869718388218004301}
+  - {fileID: 3621684999002554662}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -126,8 +128,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   noteType: 1
-  meshRenderer: {fileID: 6664786436042441321}
-  Pressed: 0
+  meshRenderer: {fileID: 5263522728343485837}
 --- !u!1 &6784043714968123631
 GameObject:
   m_ObjectHideFlags: 0
@@ -239,7 +240,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 7011296361675420656}
-  m_RootOrder: 0
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1083648823376758024
 MeshFilter:

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Input/KeyViewController.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Input/KeyViewController.cs
@@ -64,7 +64,7 @@ namespace CyanStars.Gameplay.MusicGame
             {
                 key = Instantiate(keyPrefab);
                 var trans = key.transform;
-                trans.position = new Vector3(Endpoint.Instance.GetPosWithRatio(args.RangeMin), 0, 20);
+                trans.position = new Vector3(Endpoint.Instance.GetPosWithRatio(args.RangeMin), -0.045f, 20);
                 trans.localScale = new Vector3(Endpoint.Instance.Length * args.RangeWidth, 0.1f, 10000);
                 trans.SetParent(transform);
                 KeyDict.Add(args.ID, key);

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Input/KeyViewController.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Input/KeyViewController.cs
@@ -62,6 +62,7 @@ namespace CyanStars.Gameplay.MusicGame
             }
             else
             {
+                //ToDo: key预计在后续重新设计样式至半透明灰色
                 key = Instantiate(keyPrefab);
                 var trans = key.transform;
                 trans.position = new Vector3(Endpoint.Instance.GetPosWithRatio(args.RangeMin), -0.045f, 20);


### PR DESCRIPTION
- 降低了key高度，现在key不会与note重叠导致显示时闪烁了
- 重新分配了hold的渲染组件，hold可以在按住时正常播放动画效果了