### PR TITLE
feat: 为音游成绩和难度枚举类添加注释说明

### DIFF
--- a/Cyan-Stars/Assets/Scripts/Gameplay/GameSave/ChartGrade.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/GameSave/ChartGrade.cs
@@ -3,6 +3,9 @@ namespace CyanStars.Gameplay.GameSave
     /// <summary>
     /// 音游谱面成绩评级
     /// </summary>
+    /// <remarks>
+    /// 可为null，代表玩家从未游玩/完成过该谱面
+    /// </remarks>
     public enum ChartGrade
     {
         Clear,

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/MapData/ChartDifficulty.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/MapData/ChartDifficulty.cs
@@ -5,9 +5,10 @@ namespace CyanStars.Gameplay.MusicGame
     /// </summary>
     public enum ChartDifficulty
     {
-        KuiXing = 0, // 窥星（最简单）
-        QiMing = 1, // 启明
-        TianShu = 2, // 天枢
-        WuYin = 3 // 无垠（最难）
+        Undefined = 0, // 未定义的难度，可有多个存在于谱包内，可以被谱面编辑器加载，但不会被游戏加载
+        KuiXing = 1, // 窥星（最简单）
+        QiMing = 2, // 启明
+        TianShu = 3, // 天枢
+        WuYin = 4 // 无垠（最难）
     }
 }

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/MapData/ChartDifficulty.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/MapData/ChartDifficulty.cs
@@ -3,12 +3,14 @@ namespace CyanStars.Gameplay.MusicGame
     /// <summary>
     /// 谱面难度
     /// </summary>
+    /// <remarks>
+    /// 可为null，代表未定义难度的谱面，可在编辑器内编辑，但不能被游戏读取
+    /// </remarks>
     public enum ChartDifficulty
     {
-        Undefined = 0, // 未定义的难度，可有多个存在于谱包内，可以被谱面编辑器加载，但不会被游戏加载
-        KuiXing = 1, // 窥星（最简单）
-        QiMing = 2, // 启明
-        TianShu = 3, // 天枢
-        WuYin = 4 // 无垠（最难）
+        KuiXing = 0, // 窥星（最简单）
+        QiMing = 1, // 启明
+        TianShu = 2, // 天枢
+        WuYin = 3 // 无垠（最难）
     }
 }


### PR DESCRIPTION
- Grade 新增说明，玩家从未完成游玩的谱面为null
- Difficulty 新增说明，null的谱面允许多个存在谱包内和被编辑器修改，但不被游戏读取