### PR TITLE
Feat: 自定义可交互组件状态和动效处理

### DIFF
--- a/Cyan-Stars/Assets/Scripts/Utils/SelectableUI.meta
+++ b/Cyan-Stars/Assets/Scripts/Utils/SelectableUI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 24987776476a3fd4cbcd3cfe6f1faed1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableStateObserver.cs
+++ b/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableStateObserver.cs
@@ -120,27 +120,22 @@ namespace CyanStars.Utils.SelectableUI
             if (!selectable.IsInteractable())
             {
                 // 禁止交互
-                newState = UIState.Disabled;
+                newState = isKeepSelected ? UIState.DisabledSelected : UIState.Disabled;
             }
             else if (isPressed && (isHovered || isFocused))
             {
                 // 按下，且鼠标不移出组件区域/是键盘手柄导航焦点
-                newState = UIState.Pressed;
-            }
-            else if (isKeepSelected)
-            {
-                // 选中（常见于 toggle）
-                newState = UIState.Selected;
+                newState = isKeepSelected ? UIState.PressedSelected : UIState.Pressed;
             }
             else if (isHovered || isFocused)
             {
                 // 鼠标悬浮/键盘手柄导航焦点
-                newState = UIState.Hover;
+                newState = isKeepSelected ? UIState.HoverSelected : UIState.Hover;
             }
             else
             {
                 // 待机
-                newState = UIState.Normal;
+                newState = isKeepSelected ? UIState.NormalSelected : UIState.Normal;
             }
 
             // 如果状态发生变化，则执行表现更新
@@ -206,9 +201,12 @@ namespace CyanStars.Utils.SelectableUI
     {
         // 越下方优先级越高，目前是用 if 手动判断优先级
         Normal, // 待机
+        NormalSelected, // 待机+已选中 (仅Toggle)
         Hover, // 鼠标悬浮
-        Selected, // 已选中 (仅Toggle)
+        HoverSelected, // 鼠标悬浮+已选中 (仅Toggle)
         Pressed, // 鼠标按下&按住
-        Disabled // 禁止交互
+        PressedSelected, // 鼠标按下&按住+已选中 (仅Toggle)
+        Disabled, // 禁止交互
+        DisabledSelected // 禁止交互+已选中 (仅Toggle)
     }
 }

--- a/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableStateObserver.cs
+++ b/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableStateObserver.cs
@@ -1,0 +1,226 @@
+#nullable enable
+
+using System;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace CyanStars.Utils.SelectableUI
+{
+    /// <summary>
+    /// 用于为 Button 和 Toggle 提供玩家 UI 交互状态触发
+    /// </summary>
+    /// <remarks>
+    /// 玩家在 UI 上点击/悬浮/导航时，本脚本会检测交互、更新状态、触发回调，但不直接负责渲染动效
+    /// 注意不要再直接修改 selectable.interactable，改为调用 SetInteractable()
+    /// 用法：
+    /// 1. 挂载在 Button 或 toggle 物体上
+    /// 2. 将 Button 或 toggle 组件的过渡设为 None，否则程序会在运行时警告并覆盖
+    /// 3. 按照正常的 Unity 方式（onClick/onValueChanged.AddListener 或拖拽）监听并处理 Selectable 的逻辑事件
+    /// 4. 再写一个脚本监听并处理本脚本的 OnStateChanged 视图事件
+    /// </remarks>
+    [RequireComponent(typeof(Selectable))]
+    public class SelectableStateObserver : UIBehaviour,
+        IPointerEnterHandler, IPointerExitHandler,
+        IPointerDownHandler, IPointerUpHandler,
+        ISelectHandler, IDeselectHandler
+    {
+        public UIState CurrentState { get; private set; } = UIState.Normal;
+
+
+        [Header("状态改变回调")]
+        public UIStateChangeEvent OnStateChanged = new();
+
+        [SerializeField]
+        private Selectable? selectable;
+
+
+        /// <remarks>
+        /// selectable as Toggle
+        /// </remarks>
+        private Toggle? toggle;
+
+
+        private bool isHovered = false; // 鼠标悬浮
+        private bool isFocused = false; // 键盘/手柄导航焦点
+        private bool isPressed = false; // 按住
+
+
+        /// <summary>
+        /// 外部手动修改组件可交互性，同时一并触发视觉效果更新
+        /// </summary>
+        public void SetInteractable(bool interactable)
+        {
+            // 考虑到 UI 内可能有大量组件，故不采用 Update() 自动轮询
+            selectable!.interactable = interactable;
+            EvaluateState();
+        }
+
+
+#if UNITY_EDITOR
+        protected override void Reset()
+        {
+            // Unity 编辑器内自动抓取组件，无需手动拖拽
+            base.Reset();
+            if (selectable == null)
+                selectable = GetComponent<Selectable>();
+        }
+#endif
+
+        protected override void Awake()
+        {
+            base.Awake();
+            if (selectable == null)
+                selectable = GetComponent<Selectable>();
+
+            if (selectable.transition != Selectable.Transition.None)
+            {
+                Debug.LogWarning($"{nameof(SelectableStateObserver)} 已自动禁用 selectable.transition，请检查是否为预期效果。", gameObject);
+                selectable.transition = Selectable.Transition.None;
+            }
+
+            toggle = selectable as Toggle;
+        }
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            if (toggle != null)
+                toggle.onValueChanged.AddListener(OnToggleValueChanged);
+
+
+            isHovered = false;
+            isFocused = false;
+            isPressed = false;
+            EvaluateState();
+        }
+
+        protected override void OnCanvasGroupChanged()
+        {
+            base.OnCanvasGroupChanged();
+            EvaluateState();
+        }
+
+        protected override void OnDisable()
+        {
+            base.OnDisable();
+            if (toggle != null)
+                toggle.onValueChanged.RemoveListener(OnToggleValueChanged);
+
+
+            isHovered = false;
+            isFocused = false;
+            isPressed = false;
+            CurrentState = UIState.Normal;
+        }
+
+
+        /// <summary>
+        /// 当 selectable 是 toggle 时，外界改变 toggle.isOn 时也会自动改变视觉效果
+        /// </summary>
+        private void OnToggleValueChanged(bool value)
+        {
+            EvaluateState();
+        }
+
+        private void EvaluateState()
+        {
+            UIState newState;
+
+            if (!selectable!.IsInteractable())
+            {
+                // 禁止交互
+                newState = UIState.Disabled;
+            }
+            else if (isPressed && (isHovered || isFocused))
+            {
+                // 按下，且鼠标不移出组件区域/是键盘手柄导航焦点
+                newState = UIState.Pressed;
+            }
+            else if (toggle != null && toggle.isOn)
+            {
+                // 选中（仅 toggle）
+                newState = UIState.Selected;
+            }
+            else if (isHovered || isFocused)
+            {
+                // 鼠标悬浮/键盘手柄导航焦点
+                newState = UIState.Hover;
+            }
+            else
+            {
+                // 待机
+                newState = UIState.Normal;
+            }
+
+            // 如果状态发生变化，则执行表现更新
+            if (newState != CurrentState)
+            {
+                CurrentState = newState;
+                OnStateChanged.Invoke(CurrentState);
+            }
+        }
+
+
+        public void OnPointerEnter(PointerEventData eventData)
+        {
+            isHovered = true;
+            EvaluateState();
+        }
+
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            isHovered = false;
+            EvaluateState();
+        }
+
+        public void OnPointerDown(PointerEventData eventData)
+        {
+            if (eventData.button != PointerEventData.InputButton.Left) return;
+            isPressed = true;
+            EvaluateState();
+        }
+
+        public void OnPointerUp(PointerEventData eventData)
+        {
+            if (eventData.button != PointerEventData.InputButton.Left) return;
+            isPressed = false;
+            EvaluateState();
+        }
+
+        // 键盘/手柄导航事件视为鼠标悬浮
+        public void OnSelect(BaseEventData eventData)
+        {
+            isFocused = true;
+            EvaluateState();
+        }
+
+        public void OnDeselect(BaseEventData eventData)
+        {
+            isFocused = false;
+            EvaluateState();
+        }
+    }
+
+    /// <summary>
+    /// 提供 Unity 式可订阅的能力
+    /// </summary>
+    /// <example>
+    /// selectable.OnStateChanged.AddListener(()=>{});
+    /// </example>
+    [Serializable]
+    public class UIStateChangeEvent : UnityEvent<UIState>
+    {
+    }
+
+    public enum UIState
+    {
+        // 越下方优先级越高，目前是用 if 手动判断优先级
+        Normal, // 待机
+        Hover, // 鼠标悬浮
+        Selected, // 已选中 (仅Toggle)
+        Pressed, // 鼠标按下&按住
+        Disabled // 禁止交互
+    }
+}

--- a/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableStateObserver.cs
+++ b/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableStateObserver.cs
@@ -1,6 +1,5 @@
 #nullable enable
 
-using System;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.EventSystems;
@@ -18,8 +17,9 @@ namespace CyanStars.Utils.SelectableUI
     /// 1. 挂载在 Button 或 toggle 物体上
     /// 2. 将 Button 或 toggle 组件的过渡设为 None，否则程序会在运行时警告并覆盖
     /// 3. 按照正常的 Unity 方式（onClick/onValueChanged.AddListener 或拖拽）监听并处理 Selectable 的逻辑事件
-    /// 4. 再写一个脚本监听并处理本脚本的 OnStateChanged 视图事件
+    /// 4. 再写一个脚本监听并处理本脚本的 OnStateChanged 视图事件（参见 SelectableViewEffectHandler）
     /// </remarks>
+    [DisallowMultipleComponent]
     [RequireComponent(typeof(Selectable))]
     public class SelectableStateObserver : UIBehaviour,
         IPointerEnterHandler, IPointerExitHandler,
@@ -30,21 +30,14 @@ namespace CyanStars.Utils.SelectableUI
 
 
         [Header("状态改变回调")]
-        public UIStateChangeEvent OnStateChanged = new();
+        public UnityEvent<UIState> OnStateChanged = new();
 
-        [SerializeField]
-        private Selectable? selectable;
+        private Selectable selectable = null!;
 
-
-        /// <remarks>
-        /// selectable as Toggle
-        /// </remarks>
-        private Toggle? toggle;
-
-
-        private bool isHovered = false; // 鼠标悬浮
-        private bool isFocused = false; // 键盘/手柄导航焦点
-        private bool isPressed = false; // 按住
+        private bool isKeepSelected; // 被选中（如果组件是 Toggle，将自动从 toggle.isOn 同步）
+        private bool isHovered; // 鼠标悬浮
+        private bool isFocused; // 键盘/手柄导航焦点
+        private bool isPressed; // 按住
 
 
         /// <summary>
@@ -53,26 +46,16 @@ namespace CyanStars.Utils.SelectableUI
         public void SetInteractable(bool interactable)
         {
             // 考虑到 UI 内可能有大量组件，故不采用 Update() 自动轮询
-            selectable!.interactable = interactable;
+            selectable.interactable = interactable;
             EvaluateState();
         }
 
 
-#if UNITY_EDITOR
-        protected override void Reset()
-        {
-            // Unity 编辑器内自动抓取组件，无需手动拖拽
-            base.Reset();
-            if (selectable == null)
-                selectable = GetComponent<Selectable>();
-        }
-#endif
-
         protected override void Awake()
         {
             base.Awake();
-            if (selectable == null)
-                selectable = GetComponent<Selectable>();
+
+            selectable = GetComponent<Selectable>();
 
             if (selectable.transition != Selectable.Transition.None)
             {
@@ -80,16 +63,18 @@ namespace CyanStars.Utils.SelectableUI
                 selectable.transition = Selectable.Transition.None;
             }
 
-            toggle = selectable as Toggle;
+            if (TryGetComponent<Toggle>(out var toggle))
+            {
+                isKeepSelected = toggle.isOn;
+                toggle.onValueChanged.AddListener(OnToggleValueChanged);
+            }
         }
 
         protected override void OnEnable()
         {
             base.OnEnable();
-            if (toggle != null)
-                toggle.onValueChanged.AddListener(OnToggleValueChanged);
 
-
+            isKeepSelected = false;
             isHovered = false;
             isFocused = false;
             isPressed = false;
@@ -105,10 +90,11 @@ namespace CyanStars.Utils.SelectableUI
         protected override void OnDisable()
         {
             base.OnDisable();
-            if (toggle != null)
+
+            if (TryGetComponent<Toggle>(out var toggle))
                 toggle.onValueChanged.RemoveListener(OnToggleValueChanged);
 
-
+            isKeepSelected = false;
             isHovered = false;
             isFocused = false;
             isPressed = false;
@@ -121,6 +107,9 @@ namespace CyanStars.Utils.SelectableUI
         /// </summary>
         private void OnToggleValueChanged(bool value)
         {
+            if (isKeepSelected == value)
+                return;
+            isKeepSelected = value;
             EvaluateState();
         }
 
@@ -128,7 +117,7 @@ namespace CyanStars.Utils.SelectableUI
         {
             UIState newState;
 
-            if (!selectable!.IsInteractable())
+            if (!selectable.IsInteractable())
             {
                 // 禁止交互
                 newState = UIState.Disabled;
@@ -138,9 +127,9 @@ namespace CyanStars.Utils.SelectableUI
                 // 按下，且鼠标不移出组件区域/是键盘手柄导航焦点
                 newState = UIState.Pressed;
             }
-            else if (toggle != null && toggle.isOn)
+            else if (isKeepSelected)
             {
-                // 选中（仅 toggle）
+                // 选中（常见于 toggle）
                 newState = UIState.Selected;
             }
             else if (isHovered || isFocused)
@@ -203,16 +192,6 @@ namespace CyanStars.Utils.SelectableUI
         }
     }
 
-    /// <summary>
-    /// 提供 Unity 式可订阅的能力
-    /// </summary>
-    /// <example>
-    /// selectable.OnStateChanged.AddListener(()=>{});
-    /// </example>
-    [Serializable]
-    public class UIStateChangeEvent : UnityEvent<UIState>
-    {
-    }
 
     public enum UIState
     {

--- a/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableStateObserver.cs
+++ b/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableStateObserver.cs
@@ -30,7 +30,10 @@ namespace CyanStars.Utils.SelectableUI
 
 
         [Header("状态改变回调")]
-        public UnityEvent<UIState> OnStateChanged = new();
+        [SerializeField]
+        private UnityEvent<UIState> onStateChanged;
+
+        public UnityEvent<UIState> OnStateChanged => onStateChanged;
 
         private Selectable selectable = null!;
 
@@ -142,7 +145,7 @@ namespace CyanStars.Utils.SelectableUI
             if (newState != CurrentState)
             {
                 CurrentState = newState;
-                OnStateChanged.Invoke(CurrentState);
+                onStateChanged.Invoke(CurrentState);
             }
         }
 

--- a/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableStateObserver.cs
+++ b/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableStateObserver.cs
@@ -166,15 +166,24 @@ namespace CyanStars.Utils.SelectableUI
 
         public void OnPointerDown(PointerEventData eventData)
         {
-            if (eventData.button != PointerEventData.InputButton.Left) return;
+            if (eventData.button != PointerEventData.InputButton.Left)
+                return;
+
             isPressed = true;
             EvaluateState();
         }
 
         public void OnPointerUp(PointerEventData eventData)
         {
-            if (eventData.button != PointerEventData.InputButton.Left) return;
+            if (eventData.button != PointerEventData.InputButton.Left)
+                return;
+
             isPressed = false;
+
+            // 抬起鼠标时清除焦点，防止卡在 Hover 状态
+            if (EventSystem.current != null && EventSystem.current.currentSelectedGameObject == gameObject)
+                EventSystem.current.SetSelectedGameObject(null);
+
             EvaluateState();
         }
 

--- a/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableStateObserver.cs.meta
+++ b/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableStateObserver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 402188e82ed34674aa269388b0a1fbad

--- a/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableViewEffectHandler.cs
+++ b/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableViewEffectHandler.cs
@@ -63,6 +63,7 @@ namespace CyanStars.Utils.SelectableUI
 
         private void Start()
         {
+            OnStateChanged(observer.CurrentState); // 启动时更新一次视觉效果
             observer.OnStateChanged.AddListener(OnStateChanged);
         }
 

--- a/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableViewEffectHandler.cs
+++ b/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableViewEffectHandler.cs
@@ -27,26 +27,35 @@ namespace CyanStars.Utils.SelectableUI
 
         [Header("动画设置")]
         [SerializeField]
-        private float tweenDuration = 0.15f;
+        private float tweenDuration = 0.1f;
 
         [SerializeField]
         private Ease tweenEase = Ease.OutQuad;
 
         [Header("各状态配置")]
         [SerializeField]
-        private StateEffectConfig normalState = new() { Scale = Vector3.one, TintColor = new Color(1f, 1f, 1f, 0.98f) };
+        private StateEffectConfig normalState = new() { Scale = Vector3.one, TintColor = new Color(0.93f, 0.93f, 0.93f, 0.98f) };
 
         [SerializeField]
-        private StateEffectConfig hoverState = new() { Scale = new Vector3(1.01f, 1.01f, 1.01f), TintColor = new Color(1f, 0.86f, 0.4f, 0.98f) };
+        private StateEffectConfig normalSelectedState = new() { Scale = Vector3.one, TintColor = new Color(0.27f, 0.47f, 0.82f, 0.98f) };
 
         [SerializeField]
-        private StateEffectConfig pressedState = new() { Scale = new Vector3(0.99f, 0.99f, 0.99f), TintColor = new Color(0.44f, 0.37f, 0.16f, 0.98f) };
+        private StateEffectConfig hoverState = new() { Scale = new Vector3(1.02f, 1.02f, 1.02f), TintColor = new Color(0.98f, 0.98f, 0.98f, 0.98f) };
 
         [SerializeField]
-        private StateEffectConfig selectedState = new() { Scale = Vector3.one, TintColor = new Color(0.81f, 0.64f, 0.06f, 0.98f) };
+        private StateEffectConfig hoverSelectedState = new() { Scale = new Vector3(1.02f, 1.02f, 1.02f), TintColor = new Color(0.49f, 0.63f, 0.87f, 0.98f) };
 
         [SerializeField]
-        private StateEffectConfig disabledState = new() { Scale = Vector3.one, TintColor = new Color(0.7f, 0.7f, 0.7f, 0.95f) };
+        private StateEffectConfig pressedState = new() { Scale = new Vector3(0.98f, 0.98f, 0.98f), TintColor = new Color(0.62f, 0.62f, 0.62f, 0.98f) };
+
+        [SerializeField]
+        private StateEffectConfig pressedSelectedState = new() { Scale = new Vector3(0.98f, 0.98f, 0.98f), TintColor = new Color(0.29f, 0.42f, 0.62f, 0.98f) };
+
+        [SerializeField]
+        private StateEffectConfig disabledState = new() { Scale = Vector3.one, TintColor = new Color(0.33f, 0.33f, 0.33f, 0.98f) };
+
+        [SerializeField]
+        private StateEffectConfig disabledSelectedState = new() { Scale = Vector3.one, TintColor = new Color(0.11f, 0.19f, 0.33f, 0.98f) };
 
         private Transform transformToChangeScale = null!;
         private Selectable selectable = null!;
@@ -83,17 +92,26 @@ namespace CyanStars.Utils.SelectableUI
                 case UIState.Normal:
                     ApplyEffect(normalState);
                     break;
+                case UIState.NormalSelected:
+                    ApplyEffect(normalSelectedState);
+                    break;
                 case UIState.Hover:
                     ApplyEffect(hoverState);
                     break;
-                case UIState.Selected:
-                    ApplyEffect(selectedState);
+                case UIState.HoverSelected:
+                    ApplyEffect(hoverSelectedState);
                     break;
                 case UIState.Pressed:
                     ApplyEffect(pressedState);
                     break;
+                case UIState.PressedSelected:
+                    ApplyEffect(pressedSelectedState);
+                    break;
                 case UIState.Disabled:
                     ApplyEffect(disabledState);
+                    break;
+                case UIState.DisabledSelected:
+                    ApplyEffect(disabledSelectedState);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(state), state, null);

--- a/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableViewEffectHandler.cs
+++ b/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableViewEffectHandler.cs
@@ -1,0 +1,153 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using DG.Tweening;
+
+namespace CyanStars.Utils.SelectableUI
+{
+    [RequireComponent(typeof(Selectable))]
+    [RequireComponent(typeof(SelectableStateObserver))]
+    public class SelectableViewEffectHandler : MonoBehaviour
+    {
+        [Header("组件引用")]
+        [SerializeField]
+        private Transform? transformToChangeScale;
+
+        [SerializeField]
+        private Selectable? selectable;
+
+        [SerializeField]
+        private SelectableStateObserver? observer;
+
+        [SerializeField]
+        private List<MaskableGraphic> maskableGraphicToChangeColor = new();
+
+        [Header("动画设置")]
+        [SerializeField]
+        private float tweenDuration = 0.15f;
+
+        [SerializeField]
+        private Ease tweenEase = Ease.OutQuad;
+
+        [Header("各状态配置")]
+        [SerializeField]
+        private StateEffectConfig normalState = new() { Scale = Vector3.one, TintColor = new Color(1f, 1f, 1f, 0.98f) };
+
+        [SerializeField]
+        private StateEffectConfig hoverState = new() { Scale = new Vector3(1.01f, 1.01f, 1.01f), TintColor = new Color(1f, 0.86f, 0.4f, 0.98f) };
+
+        [SerializeField]
+        private StateEffectConfig pressedState = new() { Scale = new Vector3(0.99f, 0.99f, 0.99f), TintColor = new Color(0.44f, 0.37f, 0.16f, 0.98f) };
+
+        [SerializeField]
+        private StateEffectConfig selectedState = new() { Scale = Vector3.one, TintColor = new Color(0.81f, 0.64f, 0.06f, 0.98f) };
+
+        [SerializeField]
+        private StateEffectConfig disabledState = new() { Scale = Vector3.one, TintColor = new Color(0.7f, 0.7f, 0.7f, 0.95f) };
+
+
+        // 缓存当前的动画序列，用于打断旧动画
+        private Sequence? currentEffectSequence;
+
+
+#if UNITY_EDITOR
+        private void Reset()
+        {
+            if (transformToChangeScale == null)
+                transformToChangeScale = GetComponent<Transform>();
+            if (selectable == null)
+                selectable = GetComponent<Selectable>();
+            if (observer == null)
+                observer = GetComponent<SelectableStateObserver>();
+        }
+#endif
+
+        private void Awake()
+        {
+            if (transformToChangeScale == null)
+                transformToChangeScale = GetComponent<Transform>();
+            if (selectable == null)
+                selectable = GetComponent<Selectable>();
+            if (observer == null)
+                observer = GetComponent<SelectableStateObserver>();
+        }
+
+        private void Start()
+        {
+            observer!.OnStateChanged.AddListener(OnStateChanged);
+        }
+
+        private void OnDestroy()
+        {
+            observer!.OnStateChanged.RemoveListener(OnStateChanged);
+
+            currentEffectSequence?.Kill();
+            currentEffectSequence = null;
+        }
+
+
+        private void OnStateChanged(UIState state)
+        {
+            switch (state)
+            {
+                case UIState.Normal:
+                    ApplyEffect(normalState);
+                    break;
+                case UIState.Hover:
+                    ApplyEffect(hoverState);
+                    break;
+                case UIState.Selected:
+                    ApplyEffect(selectedState);
+                    break;
+                case UIState.Pressed:
+                    ApplyEffect(pressedState);
+                    break;
+                case UIState.Disabled:
+                    ApplyEffect(disabledState);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(state), state, null);
+            }
+        }
+
+        /// <summary>
+        /// 应用动画效果
+        /// </summary>
+        private void ApplyEffect(StateEffectConfig config)
+        {
+            currentEffectSequence?.Kill();
+            currentEffectSequence = DOTween.Sequence();
+
+            // 添加缩放动画
+            if (transformToChangeScale != null)
+            {
+                currentEffectSequence.Join(transformToChangeScale
+                    .DOScale(config.Scale, tweenDuration)
+                    .SetEase(tweenEase));
+            }
+
+            // 添加颜色渐变动画
+            foreach (var graphic in maskableGraphicToChangeColor)
+            {
+                if (graphic != null)
+                {
+                    currentEffectSequence.Join(graphic
+                        .DOColor(config.TintColor, tweenDuration)
+                        .SetEase(tweenEase));
+                }
+            }
+
+            currentEffectSequence.SetLink(gameObject);
+        }
+    }
+
+    [Serializable]
+    public class StateEffectConfig
+    {
+        public Vector3 Scale = Vector3.one;
+        public Color TintColor = Color.white;
+    }
+}

--- a/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableViewEffectHandler.cs
+++ b/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableViewEffectHandler.cs
@@ -8,20 +8,20 @@ using DG.Tweening;
 
 namespace CyanStars.Utils.SelectableUI
 {
+    /// <summary>
+    /// 用于为 Button 和 Toggle 处理玩家交互视觉效果
+    /// </summary>
+    /// <remarks>
+    /// 用法：
+    /// 1. 把此脚本和 SelectableStateObserver 挂载在 Button 或 toggle 物体上
+    /// 2. 把所有需要在交互时变色的图片/文字拖到 maskableGraphicToChangeColor 里面
+    /// 3. 调整效果直到满意
+    /// </remarks>
+    [DisallowMultipleComponent]
     [RequireComponent(typeof(Selectable))]
     [RequireComponent(typeof(SelectableStateObserver))]
     public class SelectableViewEffectHandler : MonoBehaviour
     {
-        [Header("组件引用")]
-        [SerializeField]
-        private Transform? transformToChangeScale;
-
-        [SerializeField]
-        private Selectable? selectable;
-
-        [SerializeField]
-        private SelectableStateObserver? observer;
-
         [SerializeField]
         private List<MaskableGraphic> maskableGraphicToChangeColor = new();
 
@@ -48,41 +48,27 @@ namespace CyanStars.Utils.SelectableUI
         [SerializeField]
         private StateEffectConfig disabledState = new() { Scale = Vector3.one, TintColor = new Color(0.7f, 0.7f, 0.7f, 0.95f) };
 
+        private Transform transformToChangeScale = null!;
+        private Selectable selectable = null!;
+        private SelectableStateObserver observer = null!;
+        private Sequence? currentEffectSequence; // 缓存当前的动画序列，用于打断旧动画
 
-        // 缓存当前的动画序列，用于打断旧动画
-        private Sequence? currentEffectSequence;
-
-
-#if UNITY_EDITOR
-        private void Reset()
-        {
-            if (transformToChangeScale == null)
-                transformToChangeScale = GetComponent<Transform>();
-            if (selectable == null)
-                selectable = GetComponent<Selectable>();
-            if (observer == null)
-                observer = GetComponent<SelectableStateObserver>();
-        }
-#endif
 
         private void Awake()
         {
-            if (transformToChangeScale == null)
-                transformToChangeScale = GetComponent<Transform>();
-            if (selectable == null)
-                selectable = GetComponent<Selectable>();
-            if (observer == null)
-                observer = GetComponent<SelectableStateObserver>();
+            transformToChangeScale = GetComponent<Transform>();
+            selectable = GetComponent<Selectable>();
+            observer = GetComponent<SelectableStateObserver>();
         }
 
         private void Start()
         {
-            observer!.OnStateChanged.AddListener(OnStateChanged);
+            observer.OnStateChanged.AddListener(OnStateChanged);
         }
 
         private void OnDestroy()
         {
-            observer!.OnStateChanged.RemoveListener(OnStateChanged);
+            observer.OnStateChanged.RemoveListener(OnStateChanged);
 
             currentEffectSequence?.Kill();
             currentEffectSequence = null;
@@ -138,6 +124,12 @@ namespace CyanStars.Utils.SelectableUI
                         .DOColor(config.TintColor, tweenDuration)
                         .SetEase(tweenEase));
                 }
+#if UNITY_EDITOR
+                else
+                {
+                    Debug.LogError($"graphic 为 null，无法更新视觉效果，请检查");
+                }
+#endif
             }
 
             currentEffectSequence.SetLink(gameObject);

--- a/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableViewEffectHandler.cs
+++ b/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableViewEffectHandler.cs
@@ -127,7 +127,7 @@ namespace CyanStars.Utils.SelectableUI
 #if UNITY_EDITOR
                 else
                 {
-                    Debug.LogError($"graphic 为 null，无法更新视觉效果，请检查");
+                    Debug.LogError($"graphic 为 null，无法更新视觉效果，请检查", gameObject);
                 }
 #endif
             }

--- a/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableViewEffectHandler.cs
+++ b/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableViewEffectHandler.cs
@@ -108,12 +108,10 @@ namespace CyanStars.Utils.SelectableUI
             currentEffectSequence = DOTween.Sequence();
 
             // 添加缩放动画
-            if (transformToChangeScale != null)
-            {
-                currentEffectSequence.Join(transformToChangeScale
-                    .DOScale(config.Scale, tweenDuration)
-                    .SetEase(tweenEase));
-            }
+            currentEffectSequence.Join(transformToChangeScale
+                .DOScale(config.Scale, tweenDuration)
+                .SetEase(tweenEase));
+
 
             // 添加颜色渐变动画
             foreach (var graphic in maskableGraphicToChangeColor)

--- a/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableViewEffectHandler.cs.meta
+++ b/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableViewEffectHandler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ea1e68ef37657d54b8e7bfa93b4973a7


### PR DESCRIPTION
采用了自定义的状态机来替换 Unity 本身的 Button/Toggle 组件状态机，以提供更好的视觉反馈。

- SelectableStateObserver 用于获取鼠标/键盘/手柄的输入，并转换到状态，同时触发回调
- SelectableViewEffectHandler 用于处理回调，用 DoTween 来处理缩放、颜色变化

使用时将两个脚本同时挂载到 Button/Toggle 上即可，不影响原有的 Button/Toggle 按下时的逻辑回调触发。

对原有的组件有一些变更：挂载脚本后，Button/Toggle 的过渡会被强制设定为 null；不应当直接修改 interactable，应该通过 SelectableStateObserver.SetInteractable();

目前只写了代码，没有更新编辑器内的各个组件，打算在下个 pr 更新组件，并且好好整理一轮预制体。

![f7517fc42b5694a526a090c78ddd20aa](https://github.com/user-attachments/assets/2bffbf35-6bf0-4536-94af-cff954c1db62)
