### PR TITLE
enhance: 为项目指定CyanStars根命名空间

### DIFF
--- a/Cyan-Stars/ProjectSettings/EditorSettings.asset
+++ b/Cyan-Stars/ProjectSettings/EditorSettings.asset
@@ -3,28 +3,48 @@
 --- !u!159 &1
 EditorSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 11
-  m_ExternalVersionControlSupport: Visible Meta Files
+  serializedVersion: 15
   m_SerializationMode: 2
   m_LineEndingsForNewScripts: 0
   m_DefaultBehaviorMode: 0
   m_PrefabRegularEnvironment: {fileID: 0}
   m_PrefabUIEnvironment: {fileID: 0}
   m_SpritePackerMode: 0
+  m_SpritePackerCacheSize: 10
   m_SpritePackerPaddingPower: 1
+  m_Bc7TextureCompressor: 0
   m_EtcTextureCompressorBehavior: 1
   m_EtcTextureFastCompressor: 1
   m_EtcTextureNormalCompressor: 2
   m_EtcTextureBestCompressor: 4
   m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd;asmdef;rsp;asmref
-  m_ProjectGenerationRootNamespace: 
-  m_CollabEditorSettings:
-    inProgressEnabled: 1
+  m_ProjectGenerationRootNamespace: CyanStars
   m_EnableTextureStreamingInEditMode: 1
   m_EnableTextureStreamingInPlayMode: 1
+  m_EnableEditorAsyncCPUTextureLoading: 0
   m_AsyncShaderCompilation: 1
-  m_EnterPlayModeOptionsEnabled: 0
-  m_EnterPlayModeOptions: 3
-  m_ShowLightmapResolutionOverlay: 1
+  m_PrefabModeAllowAutoSave: 1
+  m_EnterPlayModeOptionsEnabled: 1
+  m_EnterPlayModeOptions: 0
+  m_GameObjectNamingDigits: 1
+  m_GameObjectNamingScheme: 0
+  m_AssetNamingUsesSpace: 1
+  m_InspectorUseIMGUIDefaultInspector: 0
   m_UseLegacyProbeSampleCount: 0
   m_SerializeInlineMappingsOnOneLine: 1
+  m_DisableCookiesInLightmapper: 0
+  m_ShadowmaskStitching: 0
+  m_AssetPipelineMode: 1
+  m_RefreshImportMode: 0
+  m_CacheServerMode: 0
+  m_CacheServerEndpoint: 
+  m_CacheServerNamespacePrefix: default
+  m_CacheServerEnableDownload: 1
+  m_CacheServerEnableUpload: 1
+  m_CacheServerEnableAuth: 0
+  m_CacheServerEnableTls: 0
+  m_CacheServerValidationMode: 2
+  m_CacheServerDownloadBatchSize: 128
+  m_EnableEnlightenBakedGI: 0
+  m_ReferencedClipsExactNaming: 0
+  m_ForceAssetUnloadAndGCOnSceneLoad: 1


### PR DESCRIPTION
位于新增的第 21 行，这个改动应该能把编译器里一大堆命名空间不正确警告给去掉，而且能在自动整理时写入正确的命名空间