### PR TITLE
Fix: 音频留白导致无法启动

### DIFF
--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Procedure/MusicGameProcedure.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/Procedure/MusicGameProcedure.cs
@@ -486,8 +486,20 @@ namespace CyanStars.Gameplay.MusicGame
         /// </summary>
         private void UpdateTimeline(double deltaTime, object userdata)
         {
-            float timelineDeltaTime = audioSource.time - lastTime;
-            lastTime = audioSource.time;
+            // TODO: 这是个临时修复，后续实现 DSPTimer 后直接用 DspDeltaTime
+            float timelineDeltaTime = 0;
+
+            if (audioSource.time <= 0)
+            {
+                // 如果音频需要留白，则以 deltaTime 来计时留白部分
+                timelineDeltaTime = (float)deltaTime;
+            }
+            else
+            {
+                // 如果已经开始播放音频了，则暂时根据音频时间计时
+                timelineDeltaTime = audioSource.time - lastTime;
+                lastTime = audioSource.time;
+            }
 
             timeline.OnPlayingUpdate(timelineDeltaTime);
             UpdateDistanceBar(timelineDeltaTime);


### PR DESCRIPTION
在测试《盛典》这张谱面时发现的问题：

- 这张谱面音频的 offset 为正数，代表需要在音频前留白一段时间
- 进入时间轴时，时间为 0，早于 audioClip 的开始时间
- 因此未进入 audioClip，未将音频添加到 audioSource，也未调用 .Play()
- 目前 Update() 是根据两帧之间的音频时间差计算经过的时间，由于音频未在播放，故始终返回 0，始终进入不了 audioClip


做个了临时修复，在未播放音频时，直接将 deltaTime 作为时间差，开始播放后再用音频时间差计算。后续这部分会统一接入 DSP Time。