### PR TITLE
Fix: 更新选曲页详情按钮跳转URL

### DIFF
--- a/Cyan-Stars/Assets/BundleRes/Prefabs/MapSelectionUI/MapSelectionPanel.prefab
+++ b/Cyan-Stars/Assets/BundleRes/Prefabs/MapSelectionUI/MapSelectionPanel.prefab
@@ -3637,7 +3637,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c7c90d892997cdf4991833802d0c16e9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  URL: https://ipol-studio.github.io/CyanStars_Docs/database/list-of-included-music/
+  URL: https://github.com/IPOL-Studio/CyanStars/wiki/%E6%94%B6%E5%BD%95%E6%9B%B2%E5%92%8C%E5%88%9B%E4%BD%9C%E8%80%85%E5%88%97%E8%A1%A8
 --- !u!1 &7937787437632999449
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
从已停用的 docs 站点跳转到仓库 wiki