### PR TITLE
Fix: 制谱器选中画笔工具无法滚动

### DIFF
--- a/Cyan-Stars/Assets/BundleRes/Scenes/ChartEditor.unity
+++ b/Cyan-Stars/Assets/BundleRes/Scenes/ChartEditor.unity
@@ -1374,8 +1374,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1595764879}
   m_HandleRect: {fileID: 1595764877}
   m_Direction: 2
-  m_Value: 0.99999994
-  m_Size: 0.5039462
+  m_Value: 1.0000001
+  m_Size: 0.6009629
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -1876,8 +1876,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 646701638}
   m_HandleRect: {fileID: 646701636}
   m_Direction: 2
-  m_Value: 1.0000122
-  m_Size: 0.91159946
+  m_Value: 1
+  m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -4739,7 +4739,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1070775234}
   m_Direction: 2
   m_Value: 1
-  m_Size: 0.35560524
+  m_Size: 0.40864152
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -9076,7 +9076,7 @@ MonoBehaviour:
   contentRect: {fileID: 1023559425}
   beatLinesFrameRect: {fileID: 1974464501}
   notesFrameRect: {fileID: 200356153}
-  scrollRect: {fileID: 1746494794}
+  scrollRect: {fileID: 1746494796}
   judgeLineRect: {fileID: 2134614510}
 --- !u!1 &549145901
 GameObject:
@@ -17654,7 +17654,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 477995409}
   m_HandleRect: {fileID: 477995407}
   m_Direction: 2
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -28266,7 +28266,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1746494793}
   - component: {fileID: 1746494795}
-  - component: {fileID: 1746494794}
+  - component: {fileID: 1746494796}
   m_Layer: 5
   m_Name: ScrollView
   m_TagString: Untagged
@@ -28294,36 +28294,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0}
---- !u!114 &1746494794
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1746494792}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1aa08ab6e0800fa44ae55d278d1423e3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Content: {fileID: 1023559425}
-  m_Horizontal: 0
-  m_Vertical: 1
-  m_MovementType: 2
-  m_Elasticity: 0.1
-  m_Inertia: 0
-  m_DecelerationRate: 0
-  m_ScrollSensitivity: 60
-  m_Viewport: {fileID: 487915726}
-  m_HorizontalScrollbar: {fileID: 0}
-  m_VerticalScrollbar: {fileID: 0}
-  m_HorizontalScrollbarVisibility: 2
-  m_VerticalScrollbarVisibility: 2
-  m_HorizontalScrollbarSpacing: -3
-  m_VerticalScrollbarSpacing: -3
-  m_OnValueChanged:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!222 &1746494795
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -28332,6 +28302,36 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1746494792}
   m_CullTransparentMesh: 1
+--- !u!114 &1746494796
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1746494792}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ff48d4041eb5e114393c5f93c0db8eec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: CyanStars::CyanStars.Utils.CustomScrollRect
+  m_Content: {fileID: 1023559425}
+  m_Horizontal: 0
+  m_Vertical: 1
+  m_MovementType: 2
+  m_Elasticity: 0.1
+  m_Inertia: 0
+  m_DecelerationRate: 0.135
+  m_ScrollSensitivity: 60
+  m_Viewport: {fileID: 487915726}
+  m_HorizontalScrollbar: {fileID: 0}
+  m_VerticalScrollbar: {fileID: 0}
+  m_HorizontalScrollbarVisibility: 0
+  m_VerticalScrollbarVisibility: 0
+  m_HorizontalScrollbarSpacing: 0
+  m_VerticalScrollbarSpacing: 0
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &1755817816
 GameObject:
   m_ObjectHideFlags: 0

--- a/Cyan-Stars/Assets/Scripts/Gameplay/ChartEditor/View/EditAreaView.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/ChartEditor/View/EditAreaView.cs
@@ -10,6 +10,7 @@ using CyanStars.Chart;
 using CyanStars.Framework;
 using CyanStars.Gameplay.ChartEditor.Model;
 using CyanStars.Gameplay.ChartEditor.ViewModel;
+using CyanStars.Utils;
 using Gameplay.ChartEditor;
 using ObservableCollections;
 using R3;
@@ -38,7 +39,7 @@ namespace CyanStars.Gameplay.ChartEditor.View
         private RectTransform notesFrameRect = null!;
 
         [SerializeField]
-        private ScrollRect scrollRect = null!;
+        private CustomScrollRect scrollRect = null!;
 
         [SerializeField]
         private RectTransform judgeLineRect = null!;
@@ -61,7 +62,7 @@ namespace CyanStars.Gameplay.ChartEditor.View
             base.Bind(targetViewModel);
 
             ViewModel.SelectedEditTool
-                .Subscribe(tool => scrollRect.vertical = tool == EditToolType.Select) // 只有为“选择”工具时才允许拖动 scrollRect
+                .Subscribe(tool => scrollRect.IsDragEnabled = tool == EditToolType.Select) // 只有为“选择”工具时才允许拖动 scrollRect
                 .AddTo(this);
             ViewModel.ContentAddHeight
                 .Subscribe(addHeight =>

--- a/Cyan-Stars/Assets/Scripts/Utils/CustomScrollRect.cs
+++ b/Cyan-Stars/Assets/Scripts/Utils/CustomScrollRect.cs
@@ -1,0 +1,42 @@
+#nullable enable
+
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace CyanStars.Utils
+{
+    /// <summary>
+    /// 自定义 ScrollRect，用于分离鼠标拖拽和滚轮的控制
+    /// </summary>
+    public class CustomScrollRect : ScrollRect
+    {
+        /// <summary>
+        /// 是否允许鼠标/触屏拖动
+        /// </summary>
+        public bool IsDragEnabled { get; set; } = true;
+
+        public override void OnBeginDrag(PointerEventData eventData)
+        {
+            if (!IsDragEnabled)
+                return;
+
+            base.OnBeginDrag(eventData);
+        }
+
+        public override void OnDrag(PointerEventData eventData)
+        {
+            if (!IsDragEnabled)
+                return;
+
+            base.OnDrag(eventData);
+        }
+
+        public override void OnEndDrag(PointerEventData eventData)
+        {
+            if (!IsDragEnabled)
+                return;
+
+            base.OnEndDrag(eventData);
+        }
+    }
+}

--- a/Cyan-Stars/Assets/Scripts/Utils/CustomScrollRect.cs.meta
+++ b/Cyan-Stars/Assets/Scripts/Utils/CustomScrollRect.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ff48d4041eb5e114393c5f93c0db8eec


### PR DESCRIPTION
制谱器现在有个问题：除了选择工具以外，其他的工具会直接锁死编辑区域，本意是防止意外拖动，但是把滚轮也一起锁死了

写了个简单的自定义 ScrollRect，现在在选择画笔/橡皮工具时，不能拖动但能滚轮滚动。