### PR TITLE
Enhance: 优化音游和暂停 UI

### DIFF
--- a/Cyan-Stars/Assets/BundleRes/Prefabs/MusicGameUI/MusicGame3DUIPanel.prefab
+++ b/Cyan-Stars/Assets/BundleRes/Prefabs/MusicGameUI/MusicGame3DUIPanel.prefab
@@ -154,7 +154,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &6673541318301419569
 RectTransform:
   m_ObjectHideFlags: 0
@@ -291,7 +291,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &5395261318044102447
 RectTransform:
   m_ObjectHideFlags: 0
@@ -428,7 +428,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &5090593036356733322
 RectTransform:
   m_ObjectHideFlags: 0
@@ -600,7 +600,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cb488109882cf284c8db9be0c29a2ba3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  TxtGrade: {fileID: 3612869322121431603}
-  TxtImpurityRate: {fileID: 4373908580246485952}
-  TxtScoreRatio: {fileID: 5211216755963802654}
-  TxtVisibleScore: {fileID: 6410618749659017958}
+  txtGrade: {fileID: 3612869322121431603}

--- a/Cyan-Stars/Assets/BundleRes/Prefabs/MusicGameUI/MusicGameMainPanel.prefab
+++ b/Cyan-Stars/Assets/BundleRes/Prefabs/MusicGameUI/MusicGameMainPanel.prefab
@@ -142,8 +142,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 0.00ms
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: e161ce69b6906f74ab0299da48e0237b, type: 2}
-  m_sharedMaterial: {fileID: 2147374, guid: e161ce69b6906f74ab0299da48e0237b, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: c052a9674fb8c4849a28b0543cfc2e17, type: 2}
+  m_sharedMaterial: {fileID: 2147374, guid: c052a9674fb8c4849a28b0543cfc2e17, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -731,8 +731,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 0
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: e161ce69b6906f74ab0299da48e0237b, type: 2}
-  m_sharedMaterial: {fileID: 2147374, guid: e161ce69b6906f74ab0299da48e0237b, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: c052a9674fb8c4849a28b0543cfc2e17, type: 2}
+  m_sharedMaterial: {fileID: 2147374, guid: c052a9674fb8c4849a28b0543cfc2e17, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -1084,8 +1084,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 1000000
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: e161ce69b6906f74ab0299da48e0237b, type: 2}
-  m_sharedMaterial: {fileID: 2147374, guid: e161ce69b6906f74ab0299da48e0237b, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: c052a9674fb8c4849a28b0543cfc2e17, type: 2}
+  m_sharedMaterial: {fileID: 2147374, guid: c052a9674fb8c4849a28b0543cfc2e17, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []

--- a/Cyan-Stars/Assets/BundleRes/Prefabs/MusicGameUI/MusicGameMainPanel.prefab
+++ b/Cyan-Stars/Assets/BundleRes/Prefabs/MusicGameUI/MusicGameMainPanel.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &18580882017107125
+--- !u!1 &56106168328348575
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,77 +8,210 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 3519299215683136557}
-  - component: {fileID: 671414077200992640}
-  - component: {fileID: 5216116708084086887}
+  - component: {fileID: 7537709310500109913}
+  - component: {fileID: 5358255817499356169}
+  - component: {fileID: 7747347712460112173}
   m_Layer: 5
-  m_Name: Text
+  m_Name: Image
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &3519299215683136557
+--- !u!224 &7537709310500109913
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 18580882017107125}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_GameObject: {fileID: 56106168328348575}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5304578605785887009}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 34, y: 34}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &671414077200992640
+--- !u!222 &5358255817499356169
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 18580882017107125}
+  m_GameObject: {fileID: 56106168328348575}
   m_CullTransparentMesh: 1
---- !u!114 &5216116708084086887
+--- !u!114 &7747347712460112173
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 18580882017107125}
+  m_GameObject: {fileID: 56106168328348575}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
   m_Material: {fileID: 0}
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 40
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 41
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: "\u6682\u505C"
+  m_Sprite: {fileID: 21300000, guid: 2fe750d7bc276f84081979bc771edd2f, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4387760934640866018
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4308038249291911466}
+  - component: {fileID: 7495876987001595463}
+  - component: {fileID: 5779804354808969245}
+  m_Layer: 5
+  m_Name: TxtImpurityRate
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4308038249291911466
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4387760934640866018}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7242250860799399579}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -50, y: -104}
+  m_SizeDelta: {x: 298, y: 20}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!222 &7495876987001595463
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4387760934640866018}
+  m_CullTransparentMesh: 1
+--- !u!114 &5779804354808969245
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4387760934640866018}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 0.00ms
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: e161ce69b6906f74ab0299da48e0237b, type: 2}
+  m_sharedMaterial: {fileID: 2147374, guid: e161ce69b6906f74ab0299da48e0237b, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 3741319167
+  m_fontColor: {r: 1, g: 1, b: 1, a: 0.87058824}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 20
+  m_fontSizeBase: 20
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 0
+  m_fontSizeMax: 255
+  m_fontStyle: 0
+  m_HorizontalAlignment: 4
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &5175477950229512713
 GameObject:
   m_ObjectHideFlags: 0
@@ -89,8 +222,8 @@ GameObject:
   m_Component:
   - component: {fileID: 5304578605785887009}
   - component: {fileID: 5291099586944818276}
-  - component: {fileID: 6018990637441842032}
   - component: {fileID: 7227597398777301403}
+  - component: {fileID: 1506068808010576287}
   m_Layer: 5
   m_Name: BtnPause
   m_TagString: Untagged
@@ -108,15 +241,15 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 3519299215683136557}
+  - {fileID: 7537709310500109913}
   m_Father: {fileID: 7242250860799399579}
-  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -142, y: -76.5}
-  m_SizeDelta: {x: 132.25, y: 61.710022}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 59, y: -64}
+  m_SizeDelta: {x: 0, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5291099586944818276
 CanvasRenderer:
@@ -126,36 +259,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5175477950229512713}
   m_CullTransparentMesh: 1
---- !u!114 &6018990637441842032
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5175477950229512713}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &7227597398777301403
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -196,10 +299,24 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 6018990637441842032}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &1506068808010576287
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5175477950229512713}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.AspectRatioFitter
+  m_AspectMode: 2
+  m_AspectRatio: 1
 --- !u!1 &7242250859260611048
 GameObject:
   m_ObjectHideFlags: 0
@@ -228,15 +345,15 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7242250859462915503}
   m_Father: {fileID: 7242250860799399579}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 9.4373}
+  m_SizeDelta: {x: 0, y: 4}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &7242250859260611045
 CanvasRenderer:
@@ -259,7 +376,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0, g: 0, b: 0, a: 0}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -305,10 +422,10 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7242250859783676597}
   m_Father: {fileID: 7242250860799399579}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
@@ -425,9 +542,9 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7242250860799399579}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -500,14 +617,14 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7242250859260611051}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 9.4373}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &7242250859462915497
 CanvasRenderer:
@@ -530,7 +647,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.4, g: 0.8, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.87058824}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -575,14 +692,14 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7242250860799399579}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 1, y: 463.5}
-  m_SizeDelta: {x: 308.81097, y: 116.6019}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -64}
+  m_SizeDelta: {x: 600, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7242250859521682833
 CanvasRenderer:
@@ -614,15 +731,15 @@ MonoBehaviour:
       m_Calls: []
   m_text: 0
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 0161d805a3764c089bef00bfe00793f5, type: 2}
-  m_sharedMaterial: {fileID: 2147374, guid: 0161d805a3764c089bef00bfe00793f5, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: e161ce69b6906f74ab0299da48e0237b, type: 2}
+  m_sharedMaterial: {fileID: 2147374, guid: e161ce69b6906f74ab0299da48e0237b, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 3103779072
-  m_fontColor: {r: 0, g: 0.9150269, b: 1, a: 0.72156864}
+    rgba: 3741319167
+  m_fontColor: {r: 1, g: 1, b: 1, a: 0.87058824}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -639,31 +756,34 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 78.65
-  m_fontSizeBase: 36
+  m_fontSize: 54
+  m_fontSizeBase: 54
   m_fontWeight: 400
-  m_enableAutoSizing: 1
+  m_enableAutoSizing: 0
   m_fontSizeMin: 0
   m_fontSizeMax: 255
   m_fontStyle: 0
   m_HorizontalAlignment: 2
-  m_VerticalAlignment: 256
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -709,9 +829,9 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7242250859267684438}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -777,7 +897,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &7242250859895190170
 RectTransform:
   m_ObjectHideFlags: 0
@@ -788,9 +908,9 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7242250860799399579}
-  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -827,8 +947,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: "\u6B4C\u8BCD"
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 32b017538c342964b83132741861ed2a, type: 2}
-  m_sharedMaterial: {fileID: -5454673948775762243, guid: 32b017538c342964b83132741861ed2a, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -863,20 +983,23 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -922,15 +1045,15 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7242250860799399579}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 514, y: -51}
-  m_SizeDelta: {x: 481.03204, y: 99.9176}
-  m_Pivot: {x: 1, y: 1}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -48, y: -64}
+  m_SizeDelta: {x: 300, y: 80}
+  m_Pivot: {x: 1, y: 0.5}
 --- !u!222 &7242250860124888763
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -959,17 +1082,17 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: SCORE(DEBUG)
+  m_text: 1000000
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 0161d805a3764c089bef00bfe00793f5, type: 2}
-  m_sharedMaterial: {fileID: 2147374, guid: 0161d805a3764c089bef00bfe00793f5, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: e161ce69b6906f74ab0299da48e0237b, type: 2}
+  m_sharedMaterial: {fileID: 2147374, guid: e161ce69b6906f74ab0299da48e0237b, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 3093167872
-  m_fontColor: {r: 0, g: 1, b: 0.36550236, a: 0.72156864}
+    rgba: 3741319167
+  m_fontColor: {r: 1, g: 1, b: 1, a: 0.87058824}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -986,31 +1109,34 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 67.4
-  m_fontSizeBase: 30
+  m_fontSize: 54
+  m_fontSizeBase: 54
   m_fontWeight: 400
-  m_enableAutoSizing: 1
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 0
+  m_fontSizeMax: 255
   m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
+  m_HorizontalAlignment: 4
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -1055,16 +1181,17 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7242250859260611051}
   - {fileID: 7242250859521682839}
   - {fileID: 7242250860124888761}
+  - {fileID: 4308038249291911466}
   - {fileID: 7242250859426829891}
   - {fileID: 7242250859267684438}
   - {fileID: 7242250859895190170}
   - {fileID: 5304578605785887009}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1083,10 +1210,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f76042f3d0d94934dba1f0bdc7d63587, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  ImgProgress: {fileID: 7242250859462915502}
-  TxtCombo: {fileID: 7242250859521682838}
-  TxtScore: {fileID: 7242250860124888760}
+  imgProgress: {fileID: 7242250859462915502}
+  txtCombo: {fileID: 7242250859521682838}
+  txtScore: {fileID: 7242250860124888760}
+  txtImpurityRate: {fileID: 5779804354808969245}
   ImgFrame: {fileID: 7242250859426829890}
-  BtnStart: {fileID: 7242250859267684433}
-  TxtLrc: {fileID: 7242250859895190165}
-  BtnPause: {fileID: 7227597398777301403}
+  btnStart: {fileID: 7242250859267684433}
+  btnPause: {fileID: 7227597398777301403}

--- a/Cyan-Stars/Assets/BundleRes/Prefabs/MusicGameUI/MusicGamePausePanel.prefab
+++ b/Cyan-Stars/Assets/BundleRes/Prefabs/MusicGameUI/MusicGamePausePanel.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &444253220501363132
+--- !u!1 &1479026606412502107
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,77 +8,229 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1288961239554669397}
-  - component: {fileID: 6374470270002350884}
-  - component: {fileID: 7049497912188632060}
+  - component: {fileID: 2672554034142421069}
+  - component: {fileID: 1043867923269616820}
   m_Layer: 5
-  m_Name: Text
+  m_Name: ResumeButtonFrame
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &1288961239554669397
+--- !u!224 &2672554034142421069
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 444253220501363132}
+  m_GameObject: {fileID: 1479026606412502107}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 4489506602491146051}
-  m_RootOrder: 0
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7008129214251663144}
+  m_Father: {fileID: 4454523694615732924}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.2, y: 0.2}
-  m_AnchorMax: {x: 0.8, y: 0.8}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &6374470270002350884
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 444253220501363132}
-  m_CullTransparentMesh: 1
---- !u!114 &7049497912188632060
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: -0.00012207031, y: 385}
+  m_SizeDelta: {x: 0, y: -1302.4277}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!114 &1043867923269616820
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 444253220501363132}
+  m_GameObject: {fileID: 1479026606412502107}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.AspectRatioFitter
+  m_AspectMode: 2
+  m_AspectRatio: 1.1
+--- !u!1 &1945974017141438775
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7841800831858432722}
+  - component: {fileID: 446203914547920552}
+  - component: {fileID: 5891850926390165907}
+  - component: {fileID: 5504630001033286964}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7841800831858432722
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1945974017141438775}
+  m_LocalRotation: {x: 0, y: 0, z: 0.10886683, w: 0.9940564}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7008129214251663144}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 12.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 69.5, y: 0}
+  m_SizeDelta: {x: 257, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &446203914547920552
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1945974017141438775}
+  m_CullTransparentMesh: 1
+--- !u!114 &5891850926390165907
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1945974017141438775}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
   m_Material: {fileID: 0}
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 12800000, guid: ee1f7100046636045bf73f8fbc8a08a1, type: 3}
-    m_FontSize: 91
-    m_FontStyle: 0
-    m_BestFit: 1
-    m_MinSize: 10
-    m_MaxSize: 91
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: "\u7EE7\u7EED"
+  m_Sprite: {fileID: 21300000, guid: 158b9bd6b277bcc45a617f354f1e336b, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5504630001033286964
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1945974017141438775}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.AspectRatioFitter
+  m_AspectMode: 1
+  m_AspectRatio: 1
+--- !u!1 &1959846301283217715
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8491392630260601627}
+  - component: {fileID: 1341159493333809917}
+  - component: {fileID: 6714989827564419677}
+  - component: {fileID: 6500200052711217707}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8491392630260601627
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1959846301283217715}
+  m_LocalRotation: {x: 0, y: 0, z: 0.58212286, w: 0.8131008}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1225596949602696571}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 71.2}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 69.5, y: 0}
+  m_SizeDelta: {x: 257, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1341159493333809917
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1959846301283217715}
+  m_CullTransparentMesh: 1
+--- !u!114 &6714989827564419677
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1959846301283217715}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 158b9bd6b277bcc45a617f354f1e336b, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6500200052711217707
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1959846301283217715}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.AspectRatioFitter
+  m_AspectMode: 1
+  m_AspectRatio: 1
 --- !u!1 &2926034943625933182
 GameObject:
   m_ObjectHideFlags: 0
@@ -90,8 +242,9 @@ GameObject:
   - component: {fileID: 8608894703783155726}
   - component: {fileID: 8448626298521578691}
   - component: {fileID: 2571026216122420779}
+  - component: {fileID: 1312385387115277625}
   m_Layer: 5
-  m_Name: Image
+  m_Name: CoverImage
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -107,9 +260,9 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4454523694615732924}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -137,14 +290,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.8599502, g: 0.8414472, b: 0.9339623, a: 0.46666667}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 5b38cfde0fa4e864aa614ddf91a32324, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 7264e41f609a1714b9c64c4ff6a1e97a, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -154,7 +307,21 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &4147958583790563367
+--- !u!114 &1312385387115277625
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2926034943625933182}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.AspectRatioFitter
+  m_AspectMode: 2
+  m_AspectRatio: 2.2222223
+--- !u!1 &3281872123826348270
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -162,120 +329,50 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 3316242267268789602}
-  - component: {fileID: 2634313708109292962}
-  - component: {fileID: 4434674809011509704}
-  - component: {fileID: 9146307482139306680}
+  - component: {fileID: 5197269291082885547}
+  - component: {fileID: 4042750569245512068}
   m_Layer: 5
-  m_Name: BtnExit
+  m_Name: ExitButtonFrame
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &3316242267268789602
+--- !u!224 &5197269291082885547
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4147958583790563367}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_GameObject: {fileID: 3281872123826348270}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 5887771594484305270}
+  - {fileID: 1225596949602696571}
   m_Father: {fileID: 4454523694615732924}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 214.32649, y: -65}
-  m_SizeDelta: {x: 428.6495, y: 130}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &2634313708109292962
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4147958583790563367}
-  m_CullTransparentMesh: 1
---- !u!114 &4434674809011509704
+  m_AnchoredPosition: {x: -0.00012207031, y: -383}
+  m_SizeDelta: {x: 0, y: -1302.4277}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!114 &4042750569245512068
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4147958583790563367}
+  m_GameObject: {fileID: 3281872123826348270}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 4571119852702950221, guid: f69e34680c63f1547939e2ac198d1169, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 1
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &9146307482139306680
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4147958583790563367}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 4434674809011509704}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!1 &5287678561577432761
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.AspectRatioFitter
+  m_AspectMode: 2
+  m_AspectRatio: 1.1
+--- !u!1 &4352896424712615296
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -283,87 +380,57 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4489506602491146051}
-  - component: {fileID: 3979007386668895938}
-  - component: {fileID: 2369307657235542250}
-  - component: {fileID: 3233431402592999421}
+  - component: {fileID: 7008129214251663144}
+  - component: {fileID: 4273975542027299011}
+  - component: {fileID: 8177683377702838760}
   m_Layer: 5
-  m_Name: BtnResume
+  m_Name: ResumeButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &4489506602491146051
+--- !u!224 &7008129214251663144
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5287678561577432761}
+  m_GameObject: {fileID: 4352896424712615296}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1288961239554669397}
-  m_Father: {fileID: 4454523694615732924}
-  m_RootOrder: 1
+  - {fileID: 7841800831858432722}
+  - {fileID: 1272905787182789037}
+  m_Father: {fileID: 2672554034142421069}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 1}
-  m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -0.0000038146973, y: -63.05774}
-  m_SizeDelta: {x: 523.4038, y: 126.1155}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &3979007386668895938
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 468.7936, y: 138}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &4273975542027299011
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5287678561577432761}
+  m_GameObject: {fileID: 4352896424712615296}
   m_CullTransparentMesh: 1
---- !u!114 &2369307657235542250
+--- !u!114 &8177683377702838760
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5287678561577432761}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: -3129581660205509584, guid: f69e34680c63f1547939e2ac198d1169, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 1
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &3233431402592999421
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5287678561577432761}
+  m_GameObject: {fileID: 4352896424712615296}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
   m_Navigation:
     m_Mode: 3
     m_WrapAround: 0
@@ -371,7 +438,7 @@ MonoBehaviour:
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
+  m_Transition: 0
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
@@ -392,7 +459,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 2369307657235542250}
+  m_TargetGraphic: {fileID: 0}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -423,12 +490,13 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8608894703783155726}
-  - {fileID: 4489506602491146051}
-  - {fileID: 3316242267268789602}
+  - {fileID: 5583170941509041325}
+  - {fileID: 2672554034142421069}
+  - {fileID: 5197269291082885547}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -447,9 +515,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5d2e51c1ad284728b3c57762fbf1555c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  BtnResume: {fileID: 3233431402592999421}
-  BtnExit: {fileID: 9146307482139306680}
---- !u!1 &8903469929209357146
+  BtnResume: {fileID: 8177683377702838760}
+  BtnExit: {fileID: 7141465765067856251}
+--- !u!1 &6821760732132644979
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -457,74 +525,435 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 5887771594484305270}
-  - component: {fileID: 542047814089175428}
-  - component: {fileID: 1139344556559866788}
+  - component: {fileID: 5583170941509041325}
+  - component: {fileID: 8097300318992517061}
+  - component: {fileID: 4006668682079830330}
   m_Layer: 5
-  m_Name: Text
+  m_Name: TrackImage
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &5887771594484305270
+--- !u!224 &5583170941509041325
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8903469929209357146}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_GameObject: {fileID: 6821760732132644979}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 3316242267268789602}
-  m_RootOrder: 0
+  m_Father: {fileID: 4454523694615732924}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.2, y: 0.2}
-  m_AnchorMax: {x: 0.7, y: 0.8}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 419.42, y: 0}
+  m_SizeDelta: {x: 838.8271, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &542047814089175428
+--- !u!222 &8097300318992517061
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8903469929209357146}
+  m_GameObject: {fileID: 6821760732132644979}
   m_CullTransparentMesh: 1
---- !u!114 &1139344556559866788
+--- !u!114 &4006668682079830330
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8903469929209357146}
+  m_GameObject: {fileID: 6821760732132644979}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 12800000, guid: ee1f7100046636045bf73f8fbc8a08a1, type: 3}
-    m_FontSize: 91
-    m_FontStyle: 0
-    m_BestFit: 1
-    m_MinSize: 10
-    m_MaxSize: 91
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: "\u9000\u51FA"
+  m_Sprite: {fileID: 21300000, guid: 86d04e9577b957f4db7ec55255c24440, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6975806936311963953
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1225596949602696571}
+  - component: {fileID: 4238703951934281099}
+  - component: {fileID: 7141465765067856251}
+  m_Layer: 5
+  m_Name: ExitButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1225596949602696571
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6975806936311963953}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8491392630260601627}
+  - {fileID: 1429543076659741449}
+  m_Father: {fileID: 5197269291082885547}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 468.7936, y: 138}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &4238703951934281099
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6975806936311963953}
+  m_CullTransparentMesh: 1
+--- !u!114 &7141465765067856251
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6975806936311963953}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 0}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &8665106474942295402
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1429543076659741449}
+  - component: {fileID: 6265344657444469324}
+  - component: {fileID: 7720219022404278314}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1429543076659741449
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8665106474942295402}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1225596949602696571}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 113.01, y: -18.066}
+  m_SizeDelta: {x: -226.0203, y: -36.132}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6265344657444469324
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8665106474942295402}
+  m_CullTransparentMesh: 1
+--- !u!114 &7720219022404278314
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8665106474942295402}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\u8FD4\u56DE\u83DC\u5355"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: d17f214eb2e14e74c95fdc4e99b0187d, type: 2}
+  m_sharedMaterial: {fileID: -7204877318828142287, guid: d17f214eb2e14e74c95fdc4e99b0187d, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 54
+  m_fontSizeBase: 54
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &8855803938310312733
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1272905787182789037}
+  - component: {fileID: 8550766580293090325}
+  - component: {fileID: 6658537130652548805}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1272905787182789037
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8855803938310312733}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7008129214251663144}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 113.01016, y: 18.066002}
+  m_SizeDelta: {x: -226.0203, y: -36.132}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8550766580293090325
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8855803938310312733}
+  m_CullTransparentMesh: 1
+--- !u!114 &6658537130652548805
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8855803938310312733}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: "\u7EE7\u7EED\u6F14\u594F"
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: d17f214eb2e14e74c95fdc4e99b0187d, type: 2}
+  m_sharedMaterial: {fileID: -7204877318828142287, guid: d17f214eb2e14e74c95fdc4e99b0187d, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 54
+  m_fontSizeBase: 54
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}

--- a/Cyan-Stars/Assets/BundleRes/Prefabs/MusicGameUI/MusicGamePausePanel.prefab
+++ b/Cyan-Stars/Assets/BundleRes/Prefabs/MusicGameUI/MusicGamePausePanel.prefab
@@ -32,10 +32,10 @@ RectTransform:
   - {fileID: 7008129214251663144}
   m_Father: {fileID: 4454523694615732924}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: -0.00012207031, y: 385}
-  m_SizeDelta: {x: 0, y: -1302.4277}
+  m_AnchorMin: {x: 0, y: 0.7184723}
+  m_AnchorMax: {x: 0, y: 0.8142777}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!114 &1043867923269616820
 MonoBehaviour:
@@ -265,7 +265,7 @@ RectTransform:
   m_Father: {fileID: 4454523694615732924}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -319,7 +319,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.AspectRatioFitter
-  m_AspectMode: 2
+  m_AspectMode: 4
   m_AspectRatio: 2.2222223
 --- !u!1 &3281872123826348270
 GameObject:
@@ -353,10 +353,10 @@ RectTransform:
   - {fileID: 1225596949602696571}
   m_Father: {fileID: 4454523694615732924}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: -0.00012207031, y: -383}
-  m_SizeDelta: {x: 0, y: -1302.4277}
+  m_AnchorMin: {x: 0, y: 0.18538891}
+  m_AnchorMax: {x: 0, y: 0.28127784}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!114 &4042750569245512068
 MonoBehaviour:
@@ -528,6 +528,7 @@ GameObject:
   - component: {fileID: 5583170941509041325}
   - component: {fileID: 8097300318992517061}
   - component: {fileID: 4006668682079830330}
+  - component: {fileID: 1434970132724759789}
   m_Layer: 5
   m_Name: TrackImage
   m_TagString: Untagged
@@ -552,7 +553,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 419.42, y: 0}
-  m_SizeDelta: {x: 838.8271, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8097300318992517061
 CanvasRenderer:
@@ -592,6 +593,20 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1434970132724759789
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6821760732132644979}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.AspectRatioFitter
+  m_AspectMode: 2
+  m_AspectRatio: 0.5825188
 --- !u!1 &6975806936311963953
 GameObject:
   m_ObjectHideFlags: 0

--- a/Cyan-Stars/Assets/BundleRes/Scenes/Warm.unity
+++ b/Cyan-Stars/Assets/BundleRes/Scenes/Warm.unity
@@ -791,7 +791,7 @@ Transform:
   m_GameObject: {fileID: 552719605}
   serializedVersion: 2
   m_LocalRotation: {x: 0.46174863, y: 0, z: 0, w: 0.8870109}
-  m_LocalPosition: {x: 0, y: 15, z: 0.5}
+  m_LocalPosition: {x: 0, y: 16, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Cyan-Stars/Assets/BundleRes/Scenes/Warm.unity
+++ b/Cyan-Stars/Assets/BundleRes/Scenes/Warm.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
+  serializedVersion: 10
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -38,13 +38,12 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 1.3669162, g: 0.25823236, b: 0.084744155, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 12
-  m_GIWorkflowMode: 1
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
   m_GISettings:
     serializedVersion: 2
     m_BounceScale: 1
@@ -67,9 +66,6 @@ LightmapSettings:
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
     m_TextureCompression: 1
-    m_FinalGather: 0
-    m_FinalGatherFiltering: 1
-    m_FinalGatherRayCount: 256
     m_ReflectionCompression: 2
     m_MixedBakeMode: 2
     m_BakeBackend: 1
@@ -104,7 +100,7 @@ NavMeshSettings:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_BuildSettings:
-    serializedVersion: 2
+    serializedVersion: 3
     agentTypeID: 0
     agentRadius: 0.5
     agentHeight: 2
@@ -117,7 +113,7 @@ NavMeshSettings:
     cellSize: 0.16666667
     manualTileSize: 0
     tileSize: 256
-    accuratePlacement: 0
+    buildHeightMesh: 0
     maxJobWorkers: 0
     preserveTilesOutsideBounds: 0
     debug:
@@ -146,12 +142,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3205723}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 15, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1068476077}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &16435381
 GameObject:
@@ -180,9 +177,17 @@ MeshCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 16435381}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 4
+  serializedVersion: 5
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
@@ -197,11 +202,17 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -223,9 +234,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &16435384
 MeshFilter:
@@ -242,12 +255,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 16435381}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.7071069, y: 0.70710677, z: -0.00000037252903, w: 0.00000038019343}
   m_LocalPosition: {x: -23.660275, y: 15.000054, z: 42.50621}
   m_LocalScale: {x: 2, y: 1, z: 250}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1334202027}
-  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 180, y: 0, z: -90}
 --- !u!1 &154566117
 GameObject:
@@ -272,14 +286,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 154566117}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -15, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1597060474}
   - {fileID: 263932706}
   m_Father: {fileID: 248970330}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &248970329
 GameObject:
@@ -305,9 +320,11 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 248970329}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 552719608}
   - {fileID: 1496501033}
@@ -315,7 +332,6 @@ Transform:
   - {fileID: 2018317038141514468}
   - {fileID: 154566118}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!82 &248970331
 AudioSource:
@@ -328,6 +344,7 @@ AudioSource:
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 0}
+  m_Resource: {fileID: 0}
   m_PlayOnAwake: 1
   m_Volume: 1
   m_Pitch: 1
@@ -438,12 +455,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 263932705}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.6830129, y: 0.183012, z: 0.183012, w: 0.6830129}
   m_LocalPosition: {x: 34.33013, y: 2.5, z: 0}
   m_LocalScale: {x: 10, y: 0.5, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 154566118}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 60, y: 90, z: 90}
 --- !u!114 &263932707
 MonoBehaviour:
@@ -468,9 +486,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 263932705}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 1, y: 20, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &344729145
@@ -500,9 +526,17 @@ MeshCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 344729145}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 4
+  serializedVersion: 5
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
@@ -517,11 +551,17 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -543,9 +583,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &344729148
 MeshFilter:
@@ -562,12 +604,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 344729145}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: -0.258819, w: 0.9659259}
   m_LocalPosition: {x: -19.330128, y: 2.500007, z: 42.49996}
   m_LocalScale: {x: 1, y: 1, z: 250}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1334202027}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: -30}
 --- !u!1 &475461868
 GameObject:
@@ -598,11 +641,17 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -624,9 +673,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &475461871
 MeshFilter:
@@ -643,12 +694,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 475461868}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0.000008106232, z: 42.5}
   m_LocalScale: {x: 3, y: 1, z: 250}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1334202027}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &552719605
 GameObject:
@@ -693,9 +745,17 @@ Camera:
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -729,13 +789,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 552719605}
-  m_LocalRotation: {x: 0.38268346, y: -0.00000012665987, z: 0.00000032699785, w: 0.92387956}
-  m_LocalPosition: {x: 0, y: 15, z: -2.5}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.46174863, y: 0, z: 0, w: 0.8870109}
+  m_LocalPosition: {x: 0, y: 15, z: 0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 248970330}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 45, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 55, y: 0, z: 0}
 --- !u!114 &552719609
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -766,8 +827,19 @@ MonoBehaviour:
   m_Dithering: 0
   m_ClearDepth: 1
   m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
   m_RequiresDepthTexture: 0
   m_RequiresColorTexture: 0
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
   m_Version: 2
 --- !u!114 &552719611
 MonoBehaviour:
@@ -822,15 +894,14 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 754579191}
   m_Enabled: 1
-  serializedVersion: 10
+  serializedVersion: 12
   m_Type: 1
-  m_Shape: 0
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_Intensity: 1
   m_Range: 10
   m_SpotAngle: 30
   m_InnerSpotAngle: 21.80208
-  m_CookieSize: 10
+  m_CookieSize2D: {x: 10, y: 10}
   m_Shadows:
     m_Type: 0
     m_Resolution: -1
@@ -874,8 +945,12 @@ Light:
   m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
   m_UseBoundingSphereOverride: 0
   m_UseViewFrustumForShadowCasterCull: 1
+  m_ForceVisible: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
+  m_LightUnit: 1
+  m_LuxAtDistance: 1
+  m_EnableSpotReflector: 1
 --- !u!4 &754579193
 Transform:
   m_ObjectHideFlags: 0
@@ -883,12 +958,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 754579191}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.90535045, y: -0, z: -0, w: 0.42466524}
   m_LocalPosition: {x: 0, y: 20, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: -129.741, y: 0, z: 0}
 --- !u!1 &846356710
 GameObject:
@@ -913,18 +989,20 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 846356710}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1334202027}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &999316120
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 96a4fc8d1f7208a41b93fbe76c716876, type: 3}
@@ -972,7 +1050,7 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -7511558181221131132, guid: 96a4fc8d1f7208a41b93fbe76c716876, type: 3}
-      propertyPath: m_Materials.Array.data[0]
+      propertyPath: 'm_Materials.Array.data[0]'
       value: 
       objectReference: {fileID: 2100000, guid: 605862354e1de0a46b12585a07a38f19, type: 2}
     - target: {fileID: 919132149155446097, guid: 96a4fc8d1f7208a41b93fbe76c716876, type: 3}
@@ -984,6 +1062,9 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 96a4fc8d1f7208a41b93fbe76c716876, type: 3}
 --- !u!1 &1036616123
 GameObject:
@@ -1003,7 +1084,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!64 &1036616124
 MeshCollider:
   m_ObjectHideFlags: 0
@@ -1012,9 +1093,17 @@ MeshCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1036616123}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 4
+  serializedVersion: 5
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
@@ -1029,11 +1118,17 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1055,9 +1150,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &1036616126
 MeshFilter:
@@ -1074,12 +1171,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1036616123}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.08075015, y: 0.60470086, z: -0.023587432, w: 0.7919975}
   m_LocalPosition: {x: 34.0183, y: 7.4147, z: 23.9699}
   m_LocalScale: {x: 11.586334, y: 7.952393, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 9, y: 75, z: 3.5}
 --- !u!1 &1068476075
 GameObject:
@@ -1119,14 +1217,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1068476075}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1335608536}
   - {fileID: 3205724}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1334202026
 GameObject:
@@ -1151,9 +1250,11 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1334202026}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 846356711}
   - {fileID: 2866904245846948322}
@@ -1163,7 +1264,6 @@ Transform:
   - {fileID: 16435385}
   - {fileID: 1503663079}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1335245775
 GameObject:
@@ -1194,7 +1294,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 172515602e62fb746b5d573b38a5fe58, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isGlobal: 1
+  m_IsGlobal: 1
   priority: 0
   blendDistance: 0
   weight: 1
@@ -1206,12 +1306,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1335245775}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -6.50754, y: -2.1473684, z: 79.20459}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1335608535
 GameObject:
@@ -1236,12 +1337,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1335608535}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -15, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1068476077}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1338802224
 GameObject:
@@ -1271,9 +1373,17 @@ MeshCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1338802224}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 4
+  serializedVersion: 5
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
@@ -1288,11 +1398,17 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1314,9 +1430,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &1338802227
 MeshFilter:
@@ -1333,12 +1451,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1338802224}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: -10, z: 0}
   m_LocalScale: {x: 10000, y: 10000, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!114 &1338802230
 MonoBehaviour:
@@ -1384,12 +1503,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1496501032}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 248970330}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1503663075
 GameObject:
@@ -1418,9 +1538,17 @@ MeshCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1503663075}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 4
+  serializedVersion: 5
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
@@ -1435,11 +1563,17 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1461,9 +1595,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &1503663078
 MeshFilter:
@@ -1480,12 +1616,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1503663075}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: 0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 23.660255, y: 14.99999, z: 42.506424}
   m_LocalScale: {x: 2, y: 1, z: 250}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1334202027}
-  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
 --- !u!1 &1517606734
 GameObject:
@@ -1513,12 +1650,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1517606734}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: 0.25881818, w: 0.96592605}
   m_LocalPosition: {x: 19.330124, y: 2.4999976, z: 42.499954}
   m_LocalScale: {x: 1, y: 1, z: 250}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1334202027}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 30}
 --- !u!64 &1517606736
 MeshCollider:
@@ -1528,9 +1666,17 @@ MeshCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1517606734}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 4
+  serializedVersion: 5
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
@@ -1545,11 +1691,17 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1571,9 +1723,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!33 &1517606738
 MeshFilter:
@@ -1608,12 +1762,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1597060473}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.6830127, y: -0.18301275, z: -0.18301275, w: 0.6830127}
   m_LocalPosition: {x: -4.3301277, y: 2.5, z: 0}
   m_LocalScale: {x: 10, y: 0.5, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 154566118}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 120, y: 90, z: 90}
 --- !u!114 &1597060475
 MonoBehaviour:
@@ -1638,9 +1793,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1597060473}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 1, y: 20, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1932090984
@@ -1666,12 +1829,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1932090984}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 248970330}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1965579749
 GameObject:
@@ -1710,12 +1874,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1965579749}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -1.6832228, y: 14.519949, z: 7.9185867}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1899389578819698946
 GameObject:
@@ -1742,12 +1907,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1899389578819698946}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 248970330}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &2866904244636181353
 Transform:
@@ -1756,12 +1922,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2866904244636181354}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.6830129, y: 0.183012, z: 0.183012, w: 0.6830129}
   m_LocalPosition: {x: 19.330132, y: 2.5009909, z: 10}
   m_LocalScale: {x: 10, y: 0.5, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2866904245846948322}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 60, y: 90, z: 90}
 --- !u!1 &2866904244636181354
 GameObject:
@@ -1800,11 +1967,17 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1826,9 +1999,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!4 &2866904245846948322
 Transform:
@@ -1837,15 +2012,16 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2866904245846948323}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2866904246340284064}
   - {fileID: 2866904246244661839}
   - {fileID: 2866904244636181353}
   m_Father: {fileID: 1334202027}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2866904245846948323
 GameObject:
@@ -1900,11 +2076,17 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1926,9 +2108,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!4 &2866904246244661839
 Transform:
@@ -1937,12 +2121,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2866904246244661824}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.6830127, y: -0.18301275, z: -0.18301275, w: 0.6830127}
   m_LocalPosition: {x: -19.330128, y: 2.501001, z: 10}
   m_LocalScale: {x: 10, y: 0.5, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2866904245846948322}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 120, y: 90, z: 90}
 --- !u!4 &2866904246340284064
 Transform:
@@ -1951,12 +2136,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2866904246340284065}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0.001, z: 10}
   m_LocalScale: {x: 30, y: 0.5, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2866904245846948322}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!1 &2866904246340284065
 GameObject:
@@ -1995,11 +2181,17 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -2021,9 +2213,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &5560561418400802755
 BoxCollider:
@@ -2033,9 +2227,17 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1899389578819698946}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Size: {x: 2.25, y: 1, z: 10}
   m_Center: {x: 1.125, y: 0, z: 0}
 --- !u!114 &7953697916761478208
@@ -2053,3 +2255,16 @@ MonoBehaviour:
   id: 0
   rangeMin: 0
   rangeWidth: 0
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1334202027}
+  - {fileID: 754579193}
+  - {fileID: 1335245777}
+  - {fileID: 1068476077}
+  - {fileID: 1036616127}
+  - {fileID: 1965579751}
+  - {fileID: 248970330}
+  - {fileID: 999316120}
+  - {fileID: 1338802228}

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/MusicGamePlayData.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/MusicGamePlayData.cs
@@ -5,7 +5,7 @@ namespace CyanStars.Gameplay.MusicGame
     /// <summary>
     /// 玩家游玩音游时的数据的结构
     /// </summary>
-    public struct MusicGamePlayData
+    public class MusicGamePlayData
     {
         /* 以下的“分数”和“总分”等为Note计分：
          * Tap/Hold头/Hold尾/Click头/Click尾，各1分

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/MusicGamePlayData.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/MusicGamePlayData.cs
@@ -12,7 +12,7 @@ namespace CyanStars.Gameplay.MusicGame
          * Drag，0.25分
          * Break，2分 */
         public int Combo; // Combo数量
-        public int MaxCombo; // 玩家在此次游玩时的最大连击数量
+        public int PlayerMaxCombo; // 玩家在此次游玩时的最大连击数量
         public float Score; // 当前分数
         public float MaxScore; // 当前的理论最高分
         public float FullScore; // 全谱总分

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/MusicGamePlayingDataModule.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/MusicGamePlayingDataModule.cs
@@ -192,7 +192,7 @@ namespace CyanStars.Gameplay.MusicGame
             else
             {
                 MusicGamePlayData.Combo += addCombo;
-                MusicGamePlayData.MaxCombo = Mathf.Max(MusicGamePlayData.Combo, MusicGamePlayData.MaxCombo);
+                MusicGamePlayData.PlayerMaxCombo = Mathf.Max(MusicGamePlayData.Combo, MusicGamePlayData.PlayerMaxCombo);
                 MusicGamePlayData.Score += addScore;
             }
 

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MusicGame3DUIPanel.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MusicGame3DUIPanel.cs
@@ -16,10 +16,8 @@ namespace CyanStars.Gameplay.MusicGame
         UIPrefabName = "Assets/BundleRes/Prefabs/MusicGameUI/MusicGame3DUIPanel.prefab")]
     public class MusicGame3DUIPanel : BaseUIPanel
     {
-        public TextMeshProUGUI TxtGrade;
-        public TextMeshProUGUI TxtImpurityRate;
-        public TextMeshProUGUI TxtScoreRatio;
-        public TextMeshProUGUI TxtVisibleScore;
+        [SerializeField]
+        private TextMeshProUGUI txtGrade;
 
         private MusicGamePlayingDataModule playingDataModule;
 
@@ -31,15 +29,10 @@ namespace CyanStars.Gameplay.MusicGame
 
         public override void OnOpen()
         {
-            TxtGrade.text = "Ready?";
-            Color color = TxtGrade.color;
+            txtGrade.text = "Ready?";
+            Color color = txtGrade.color;
             color.a = 1;
-            TxtGrade.color = color;
-            TxtImpurityRate.text = $"杂率:{0:F3}ms";
-            TxtImpurityRate.color = Color.yellow;
-            TxtScoreRatio.text = $"{100:F}%"; //TODO: 已弃用，待删除
-            TxtScoreRatio.color = Color.yellow;
-            TxtVisibleScore.text = "000000";
+            txtGrade.color = color;
 
             GameRoot.Event.AddListener(EventConst.MusicGameDataRefreshEvent, OnMusicGameDataRefresh);
         }
@@ -58,12 +51,12 @@ namespace CyanStars.Gameplay.MusicGame
             Color color = Color.white;
             if (playingDataModule.IsAutoMode)
             {
-                TxtGrade.text = "AUTO";
+                txtGrade.text = "AUTO";
                 color = Color.green;
             }
             else
             {
-                TxtGrade.text = playingDataModule.MusicGamePlayData.Grade.ToString();
+                txtGrade.text = playingDataModule.MusicGamePlayData.Grade.ToString();
 
                 switch (playingDataModule.MusicGamePlayData.Grade)
                 {
@@ -87,70 +80,70 @@ namespace CyanStars.Gameplay.MusicGame
             }
 
             color.a = 1;
-            TxtGrade.color = color;
-            TxtGrade.fontSize = 12;
+            txtGrade.color = color;
+            txtGrade.fontSize = 12;
             StopAllCoroutines();
             StartCoroutine(FadeGradeTMP());
 
-            //刷新杂率
-            TxtImpurityRate.text = $"杂率:{playingDataModule.MusicGamePlayData.ImpurityRate:F3}ms";
-
-            if (playingDataModule.MusicGamePlayData.ImpurityRate < 30)
-            {
-                TxtImpurityRate.color = Color.yellow;
-            }
-            else if (playingDataModule.MusicGamePlayData.ImpurityRate < 50)
-            {
-                TxtImpurityRate.color = Color.blue;
-            }
-            else
-            {
-                TxtImpurityRate.color = Color.white;
-            }
-
-            //刷新得分率
-            float scoreRatio = 0;
-            if (playingDataModule.MusicGamePlayData.MaxScore > 0)
-            {
-                scoreRatio = playingDataModule.MusicGamePlayData.Score / playingDataModule.MusicGamePlayData.MaxScore;
-            }
-
-            TxtScoreRatio.text = $"{(scoreRatio * 100):F}%";
-
-            if (playingDataModule.MusicGamePlayData.GreatNum + playingDataModule.MusicGamePlayData.RightNum + playingDataModule.MusicGamePlayData.OutNum + playingDataModule.MusicGamePlayData.BadNum +
-                playingDataModule.MusicGamePlayData.MissNum == 0)
-            {
-                TxtScoreRatio.color = Color.yellow;
-            }
-            else
-            {
-                if (playingDataModule.MusicGamePlayData.MissNum + playingDataModule.MusicGamePlayData.BadNum == 0)
-                {
-                    TxtScoreRatio.color = Color.cyan;
-                }
-                else
-                {
-                    TxtScoreRatio.color = Color.white;
-                }
-            }
-
-            //刷新当前分数
-            TxtVisibleScore.text = ((int)(playingDataModule.MusicGamePlayData.Score / playingDataModule.MusicGamePlayData.FullScore * 100000)).ToString().PadLeft(6, '0'); //更新文本
+            // //刷新杂率
+            // TxtImpurityRate.text = $"杂率:{playingDataModule.MusicGamePlayData.ImpurityRate:F3}ms";
+            //
+            // if (playingDataModule.MusicGamePlayData.ImpurityRate < 30)
+            // {
+            //     TxtImpurityRate.color = Color.yellow;
+            // }
+            // else if (playingDataModule.MusicGamePlayData.ImpurityRate < 50)
+            // {
+            //     TxtImpurityRate.color = Color.blue;
+            // }
+            // else
+            // {
+            //     TxtImpurityRate.color = Color.white;
+            // }
+            //
+            // //刷新得分率
+            // float scoreRatio = 0;
+            // if (playingDataModule.MusicGamePlayData.MaxScore > 0)
+            // {
+            //     scoreRatio = playingDataModule.MusicGamePlayData.Score / playingDataModule.MusicGamePlayData.MaxScore;
+            // }
+            //
+            // TxtScoreRatio.text = $"{(scoreRatio * 100):F}%";
+            //
+            // if (playingDataModule.MusicGamePlayData.GreatNum + playingDataModule.MusicGamePlayData.RightNum + playingDataModule.MusicGamePlayData.OutNum + playingDataModule.MusicGamePlayData.BadNum +
+            //     playingDataModule.MusicGamePlayData.MissNum == 0)
+            // {
+            //     TxtScoreRatio.color = Color.yellow;
+            // }
+            // else
+            // {
+            //     if (playingDataModule.MusicGamePlayData.MissNum + playingDataModule.MusicGamePlayData.BadNum == 0)
+            //     {
+            //         TxtScoreRatio.color = Color.cyan;
+            //     }
+            //     else
+            //     {
+            //         TxtScoreRatio.color = Color.white;
+            //     }
+            // }
+            //
+            // //刷新当前分数
+            // TxtVisibleScore.text = ((int)(playingDataModule.MusicGamePlayData.Score / playingDataModule.MusicGamePlayData.FullScore * 100000)).ToString().PadLeft(6, '0'); //更新文本
         }
 
         private IEnumerator FadeGradeTMP()
         {
             yield return new WaitForSeconds(0.1f);
 
-            Color gradeColor = TxtGrade.color;
-            TxtGrade.fontSize = 11;
+            Color gradeColor = txtGrade.color;
+            txtGrade.fontSize = 11;
 
             float a = 1;
             while (a >= 0)
             {
                 a -= Time.deltaTime;
                 gradeColor.a = a;
-                TxtGrade.color = gradeColor;
+                txtGrade.color = gradeColor;
                 yield return null;
             }
         }

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MusicGameMainPanel.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MusicGameMainPanel.cs
@@ -109,17 +109,21 @@ namespace CyanStars.Gameplay.MusicGame
                 : playingDataModule.MusicGamePlayData.Combo.ToString();
             int score = (int)Math.Floor(playingDataModule.MusicGamePlayData.Score / playingDataModule.MusicGamePlayData.FullScore * 1000000);
             txtScore.text = score.ToString("D7");
-            decimal impurityRate = Math.Ceiling((decimal)playingDataModule.MusicGamePlayData.ImpurityRate * 100) / 100;
+            double impurityRate = Math.Ceiling(playingDataModule.MusicGamePlayData.ImpurityRate * 100) / 100;
             txtImpurityRate.text = impurityRate.ToString("F2") + "ms";
 
-            if (playingDataModule.MusicGamePlayData.MissNum > 0)
-                txtScore.color = normalColor;
-            else if (playingDataModule.MusicGamePlayData is not { GreatNum: 0, RightNum: 0, OutNum: 0, BadNum: 0, MissNum: 0 })
-                txtScore.color = fcColor;
-            else
-                txtScore.color = apColor;
+            var playData = playingDataModule.MusicGamePlayData;
+            bool isAllExact = playData is { GreatNum: 0, RightNum: 0, OutNum: 0, BadNum: 0, MissNum: 0 };
+            bool hasMiss = playData.MissNum > 0;
 
-            txtImpurityRate.color = playingDataModule.MusicGamePlayData.ImpurityRate switch
+            if (hasMiss)
+                txtScore.color = normalColor;
+            else if (isAllExact)
+                txtScore.color = apColor;
+            else
+                txtScore.color = fcColor;
+
+            txtImpurityRate.color = playData.ImpurityRate switch
             {
                 > 50 => normalColor,
                 > 30 => fcColor,

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MusicGameMainPanel.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MusicGameMainPanel.cs
@@ -17,27 +17,41 @@ namespace CyanStars.Gameplay.MusicGame
         UIPrefabName = "Assets/BundleRes/Prefabs/MusicGameUI/MusicGameMainPanel.prefab")]
     public class MusicGameMainPanel : BaseUIPanel
     {
-        public Image ImgProgress;
-        public TextMeshProUGUI TxtCombo;
-        public TextMeshProUGUI TxtScore;
+        [SerializeField]
+        private Image imgProgress;
+
+        [SerializeField]
+        private TextMeshProUGUI txtCombo;
+
+        [SerializeField]
+        private TMP_Text txtScore;
+
+        [SerializeField]
+        private TMP_Text txtImpurityRate;
+
         public Image ImgFrame;
-        public Button BtnStart;
-        public TextMeshProUGUI TxtLrc;
-        public Button BtnPause;
+
+        [SerializeField]
+        private Button btnStart;
+
+        [SerializeField]
+        private Button btnPause;
+
 
         private MusicGamePlayingDataModule playingDataModule;
+
 
         protected override void OnCreate()
         {
             playingDataModule = GameRoot.GetDataModule<MusicGamePlayingDataModule>();
 
-            BtnStart.onClick.AddListener(() =>
+            btnStart.onClick.AddListener(() =>
             {
                 GameRoot.Event.Dispatch(EventConst.MusicGameStartEvent, this, EmptyEventArgs.Create());
-                BtnStart.gameObject.SetActive(false);
+                btnStart.gameObject.SetActive(false);
             });
 
-            BtnPause.onClick.AddListener(() =>
+            btnPause.onClick.AddListener(() =>
             {
                 GameRoot.UI.OpenUIPanelAsync<MusicGamePausePanel>();
             });
@@ -45,11 +59,13 @@ namespace CyanStars.Gameplay.MusicGame
 
         public override void OnOpen()
         {
-            ImgProgress.fillAmount = 0;
-            TxtCombo.text = "0";
-            TxtScore.text = "SCORE(DEBUG):0";
-            BtnStart.gameObject.SetActive(true);
-            TxtLrc.text = null;
+            imgProgress.fillAmount = 0;
+            txtCombo.text = "0";
+            txtScore.text = "0000000";
+            txtScore.color = new Color(1, 0.841f, 0.078f, 0.87f);
+            txtImpurityRate.text = "0.00ms";
+            txtImpurityRate.color = new Color(1, 0.841f, 0.078f, 0.87f);
+            btnStart.gameObject.SetActive(true);
             Color color = ImgFrame.color;
             color.a = 0;
             ImgFrame.color = color;
@@ -68,7 +84,7 @@ namespace CyanStars.Gameplay.MusicGame
         {
             if (playingDataModule.RunningTimeline != null)
             {
-                ImgProgress.fillAmount = (float)playingDataModule.RunningTimeline.Context.CurrentTime / playingDataModule.RunningTimeline.Context.Length;
+                imgProgress.fillAmount = (float)playingDataModule.RunningTimeline.Context.CurrentTime / playingDataModule.RunningTimeline.Context.Length;
             }
         }
 
@@ -77,10 +93,27 @@ namespace CyanStars.Gameplay.MusicGame
         /// </summary>
         private void OnMusicGameDataRefresh(object sender, EventArgs args)
         {
-            TxtCombo.text = playingDataModule.MusicGamePlayData.Combo < 2
+            txtCombo.text = playingDataModule.MusicGamePlayData.Combo < 2
                 ? string.Empty
                 : playingDataModule.MusicGamePlayData.Combo.ToString();
-            TxtScore.text = "SCORE(DEBUG):" + playingDataModule.MusicGamePlayData.Score;
+            int score = (int)Math.Floor(playingDataModule.MusicGamePlayData.Score / playingDataModule.MusicGamePlayData.FullScore * 1000000);
+            txtScore.text = score.ToString("D7");
+            decimal impurityRate = Math.Ceiling((decimal)playingDataModule.MusicGamePlayData.ImpurityRate * 100) / 100;
+            txtImpurityRate.text = impurityRate.ToString("F2") + "ms";
+
+            if (playingDataModule.MusicGamePlayData.MissNum > 0)
+                txtScore.color = new Color(1, 1, 1, 0.87f);
+            else if (playingDataModule.MusicGamePlayData is not { GreatNum: 0, RightNum: 0, OutNum: 0, BadNum: 0, MissNum: 0 })
+                txtScore.color = new Color(0.4f, 0.667f, 1, 0.87f);
+            else
+                txtScore.color = new Color(1, 0.841f, 0.078f, 0.87f);
+
+            txtImpurityRate.color = playingDataModule.MusicGamePlayData.ImpurityRate switch
+            {
+                > 50 => new Color(1, 1, 1, 0.87f),
+                > 30 => new Color(0.4f, 0.667f, 1, 0.87f),
+                _ => new Color(1, 0.841f, 0.078f, 0.87f)
+            };
         }
     }
 }

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MusicGameMainPanel.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MusicGameMainPanel.cs
@@ -17,6 +17,17 @@ namespace CyanStars.Gameplay.MusicGame
         UIPrefabName = "Assets/BundleRes/Prefabs/MusicGameUI/MusicGameMainPanel.prefab")]
     public class MusicGameMainPanel : BaseUIPanel
     {
+        [Header("颜色配置")]
+        [SerializeField]
+        private Color apColor = new(1, 0.841f, 0.078f, 0.87f);
+
+        [SerializeField]
+        private Color fcColor = new(0.4f, 0.667f, 1, 0.87f);
+
+        [SerializeField]
+        private Color normalColor = new(1, 1, 1, 0.87f);
+
+        [Header("物体引用")]
         [SerializeField]
         private Image imgProgress;
 
@@ -29,13 +40,13 @@ namespace CyanStars.Gameplay.MusicGame
         [SerializeField]
         private TMP_Text txtImpurityRate;
 
-        public Image ImgFrame;
-
         [SerializeField]
         private Button btnStart;
 
         [SerializeField]
         private Button btnPause;
+
+        public Image ImgFrame; // TODO: 边框闪烁暂时弃用，待重构
 
 
         private MusicGamePlayingDataModule playingDataModule;
@@ -62,9 +73,9 @@ namespace CyanStars.Gameplay.MusicGame
             imgProgress.fillAmount = 0;
             txtCombo.text = "0";
             txtScore.text = "0000000";
-            txtScore.color = new Color(1, 0.841f, 0.078f, 0.87f);
+            txtScore.color = apColor;
             txtImpurityRate.text = "0.00ms";
-            txtImpurityRate.color = new Color(1, 0.841f, 0.078f, 0.87f);
+            txtImpurityRate.color = apColor;
             btnStart.gameObject.SetActive(true);
             Color color = ImgFrame.color;
             color.a = 0;
@@ -102,17 +113,17 @@ namespace CyanStars.Gameplay.MusicGame
             txtImpurityRate.text = impurityRate.ToString("F2") + "ms";
 
             if (playingDataModule.MusicGamePlayData.MissNum > 0)
-                txtScore.color = new Color(1, 1, 1, 0.87f);
+                txtScore.color = normalColor;
             else if (playingDataModule.MusicGamePlayData is not { GreatNum: 0, RightNum: 0, OutNum: 0, BadNum: 0, MissNum: 0 })
-                txtScore.color = new Color(0.4f, 0.667f, 1, 0.87f);
+                txtScore.color = fcColor;
             else
-                txtScore.color = new Color(1, 0.841f, 0.078f, 0.87f);
+                txtScore.color = apColor;
 
             txtImpurityRate.color = playingDataModule.MusicGamePlayData.ImpurityRate switch
             {
-                > 50 => new Color(1, 1, 1, 0.87f),
-                > 30 => new Color(0.4f, 0.667f, 1, 0.87f),
-                _ => new Color(1, 0.841f, 0.078f, 0.87f)
+                > 50 => normalColor,
+                > 30 => fcColor,
+                _ => apColor
             };
         }
     }

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/ScoreSettlement/ScoreSettlementPanel.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/ScoreSettlement/ScoreSettlementPanel.cs
@@ -173,7 +173,7 @@ namespace CyanStars.Gameplay.MusicGame.UI.ScoreSettlement
                 : Mathf.RoundToInt(musicGamePlayData.Score /
                     musicGamePlayData.FullScore * 1000000);
             targetImpurityRateNum = musicGamePlayData.ImpurityRate;
-            targetMaxComboNum = musicGamePlayData.MaxCombo;
+            targetMaxComboNum = musicGamePlayData.PlayerMaxCombo;
 
             targetExactCountNum = musicGamePlayData.ExactNum;
             targetGreatCountNum = musicGamePlayData.GreatNum;

--- a/Cyan-Stars/Assets/Scripts/Libraries/CatAsset/Resources/BundleBuildConfig.asset
+++ b/Cyan-Stars/Assets/Scripts/Libraries/CatAsset/Resources/BundleBuildConfig.asset
@@ -627,12 +627,12 @@ MonoBehaviour:
     BundleIdentifyName: BundleRes/Prefabs/MusicGameUI/MusicGamePausePanel_prefab.bundle
     Group: Base
     IsRaw: 0
-    AssetsLength: 29194
+    AssetsLength: 29687
     CompressOption: 2
     EncryptOption: 1
     Assets:
     - Name: Assets/BundleRes/Prefabs/MusicGameUI/MusicGamePausePanel.prefab
-      Length: 29194
+      Length: 29687
   - DirectoryName: BundleRes/Prefabs/ScoreSettlementUI
     BundleName: DeprecatedScoreSettlementPanel_prefab.bundle
     BundleIdentifyName: BundleRes/Prefabs/ScoreSettlementUI/DeprecatedScoreSettlementPanel_prefab.bundle
@@ -851,14 +851,14 @@ MonoBehaviour:
     BundleIdentifyName: CysMultimediaAssets/Font/Oswald/Bold.bundle
     Group: Base
     IsRaw: 0
-    AssetsLength: 2218760
+    AssetsLength: 116570
     CompressOption: 2
     EncryptOption: 1
     Assets:
     - Name: Assets/CysMultimediaAssets/Font/Oswald/Bold/Oswald-Bold SDF.asset
       Length: 31680
     - Name: Assets/CysMultimediaAssets/Font/Oswald/Bold/Oswald-Bold Shadow SDF.asset
-      Length: 2134024
+      Length: 31834
     - Name: Assets/CysMultimediaAssets/Font/Oswald/Bold/Oswald-Bold.ttf
       Length: 53056
   - DirectoryName: CysMultimediaAssets/Font/Oswald

--- a/Cyan-Stars/Assets/Scripts/Libraries/CatAsset/Resources/BundleBuildConfig.asset
+++ b/Cyan-Stars/Assets/Scripts/Libraries/CatAsset/Resources/BundleBuildConfig.asset
@@ -802,19 +802,19 @@ MonoBehaviour:
     - Name: "Assets/CysMultimediaAssets/Charts/3-\u76DB\u5178/LICENSE.txt"
       Length: 9010
   - DirectoryName: CysMultimediaAssets/Font/LxgwWenKai
-    BundleName: Blod.bundle
-    BundleIdentifyName: CysMultimediaAssets/Font/LxgwWenKai/Blod.bundle
+    BundleName: Bold.bundle
+    BundleIdentifyName: CysMultimediaAssets/Font/LxgwWenKai/Bold.bundle
     Group: Base
     IsRaw: 0
     AssetsLength: 53070713
     CompressOption: 2
     EncryptOption: 1
     Assets:
-    - Name: Assets/CysMultimediaAssets/Font/LxgwWenKai/Blod/LXGWWenKaiMono-Bold.ttf
+    - Name: Assets/CysMultimediaAssets/Font/LxgwWenKai/Bold/LXGWWenKaiMono-Bold.ttf
       Length: 15455768
-    - Name: Assets/CysMultimediaAssets/Font/LxgwWenKai/Blod/LXGWWenKaiMono-Bold-Dynamic-SDF.asset
+    - Name: Assets/CysMultimediaAssets/Font/LxgwWenKai/Bold/LXGWWenKaiMono-Bold-Dynamic-SDF.asset
       Length: 2105208
-    - Name: Assets/CysMultimediaAssets/Font/LxgwWenKai/Blod/LXGWWenKaiMono-Bold-Static-3500Chinese-SDF(FastPacking).asset
+    - Name: Assets/CysMultimediaAssets/Font/LxgwWenKai/Bold/LXGWWenKaiMono-Bold-Static-3500Chinese-SDF(FastPacking).asset
       Length: 35509737
   - DirectoryName: CysMultimediaAssets/Font/LxgwWenKai
     BundleName: Light.bundle
@@ -847,17 +847,19 @@ MonoBehaviour:
     - Name: Assets/CysMultimediaAssets/Font/LxgwWenKai/Regular/LXGWWenKaiMono-Regular-Static-3500Chinese-SDF(FastPacking).asset
       Length: 35484837
   - DirectoryName: CysMultimediaAssets/Font/Oswald
-    BundleName: Blod.bundle
-    BundleIdentifyName: CysMultimediaAssets/Font/Oswald/Blod.bundle
+    BundleName: Bold.bundle
+    BundleIdentifyName: CysMultimediaAssets/Font/Oswald/Bold.bundle
     Group: Base
     IsRaw: 0
-    AssetsLength: 84736
+    AssetsLength: 2218760
     CompressOption: 2
     EncryptOption: 1
     Assets:
-    - Name: Assets/CysMultimediaAssets/Font/Oswald/Blod/Oswald-Bold SDF.asset
+    - Name: Assets/CysMultimediaAssets/Font/Oswald/Bold/Oswald-Bold SDF.asset
       Length: 31680
-    - Name: Assets/CysMultimediaAssets/Font/Oswald/Blod/Oswald-Bold.ttf
+    - Name: Assets/CysMultimediaAssets/Font/Oswald/Bold/Oswald-Bold Shadow SDF.asset
+      Length: 2134024
+    - Name: Assets/CysMultimediaAssets/Font/Oswald/Bold/Oswald-Bold.ttf
       Length: 53056
   - DirectoryName: CysMultimediaAssets/Font/Oswald
     BundleName: ExtraLight.bundle
@@ -875,19 +877,19 @@ MonoBehaviour:
     - Name: Assets/CysMultimediaAssets/Font/Oswald/ExtraLight/Oswald-ExtraLight-Static-ASCII-SDF(FastPacking).asset
       Length: 2154329
   - DirectoryName: CysMultimediaAssets/Font/SourceHanSerifCN
-    BundleName: Blod.bundle
-    BundleIdentifyName: CysMultimediaAssets/Font/SourceHanSerifCN/Blod.bundle
+    BundleName: Bold.bundle
+    BundleIdentifyName: CysMultimediaAssets/Font/SourceHanSerifCN/Bold.bundle
     Group: Base
     IsRaw: 0
     AssetsLength: 49753269
     CompressOption: 2
     EncryptOption: 1
     Assets:
-    - Name: Assets/CysMultimediaAssets/Font/SourceHanSerifCN/Blod/SourceHanSerifCN-Bold.otf
+    - Name: Assets/CysMultimediaAssets/Font/SourceHanSerifCN/Bold/SourceHanSerifCN-Bold.otf
       Length: 12094680
-    - Name: Assets/CysMultimediaAssets/Font/SourceHanSerifCN/Blod/SourceHanSerifCN-Bold-Dynamic-SDF.asset
+    - Name: Assets/CysMultimediaAssets/Font/SourceHanSerifCN/Bold/SourceHanSerifCN-Bold-Dynamic-SDF.asset
       Length: 2107242
-    - Name: Assets/CysMultimediaAssets/Font/SourceHanSerifCN/Blod/SourceHanSerifCN-Bold-Static-3500Chinese-SDF(FastPacking).asset
+    - Name: Assets/CysMultimediaAssets/Font/SourceHanSerifCN/Bold/SourceHanSerifCN-Bold-Static-3500Chinese-SDF(FastPacking).asset
       Length: 35551347
   - DirectoryName: CysMultimediaAssets/Font/SourceHanSerifCN
     BundleName: ExtraLight.bundle
@@ -2385,6 +2387,6 @@ MonoBehaviour:
     - Name: Packages/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesUnlit.shader
       Length: 12430
   BundleCount: 188
-  AssetCount: 293
+  AssetCount: 294
   IsExactTextureSize: 0
   IsDrawDesc: 0

--- a/Cyan-Stars/Assets/Scripts/Libraries/CatAsset/Resources/BundleBuildConfig.asset
+++ b/Cyan-Stars/Assets/Scripts/Libraries/CatAsset/Resources/BundleBuildConfig.asset
@@ -603,31 +603,23 @@ MonoBehaviour:
     BundleIdentifyName: BundleRes/Prefabs/MusicGameUI/MusicGame3DUIPanel_prefab.bundle
     Group: Base
     IsRaw: 0
-    AssetsLength: 2643770
+    AssetsLength: 17920
     CompressOption: 2
     EncryptOption: 1
     Assets:
     - Name: Assets/BundleRes/Prefabs/MusicGameUI/MusicGame3DUIPanel.prefab
-      Length: 18671
-    - Name: Assets/TextMeshPro/Fonts/LiberationSans.ttf
-      Length: 350200
-    - Name: Assets/TextMeshPro/Resources/Fonts & Materials/LiberationSans SDF - Fallback.asset
-      Length: 9713
-    - Name: Assets/TextMeshPro/Resources/Fonts & Materials/LiberationSans SDF.asset
-      Length: 2256862
-    - Name: Assets/TextMeshPro/Shaders/TMP_SDF-Mobile.shader
-      Length: 8324
+      Length: 17920
   - DirectoryName: BundleRes/Prefabs/MusicGameUI
     BundleName: MusicGameMainPanel_prefab.bundle
     BundleIdentifyName: BundleRes/Prefabs/MusicGameUI/MusicGameMainPanel_prefab.bundle
     Group: Base
     IsRaw: 0
-    AssetsLength: 72948
+    AssetsLength: 75775
     CompressOption: 2
     EncryptOption: 1
     Assets:
     - Name: Assets/BundleRes/Prefabs/MusicGameUI/MusicGameMainPanel.prefab
-      Length: 33272
+      Length: 36099
     - Name: Assets/TextMeshPro/Examples & Extras/Fonts/Bangers.ttf
       Length: 39676
   - DirectoryName: BundleRes/Prefabs/MusicGameUI
@@ -635,12 +627,12 @@ MonoBehaviour:
     BundleIdentifyName: BundleRes/Prefabs/MusicGameUI/MusicGamePausePanel_prefab.bundle
     Group: Base
     IsRaw: 0
-    AssetsLength: 16431
+    AssetsLength: 29194
     CompressOption: 2
     EncryptOption: 1
     Assets:
     - Name: Assets/BundleRes/Prefabs/MusicGameUI/MusicGamePausePanel.prefab
-      Length: 16431
+      Length: 29194
   - DirectoryName: BundleRes/Prefabs/ScoreSettlementUI
     BundleName: DeprecatedScoreSettlementPanel_prefab.bundle
     BundleIdentifyName: BundleRes/Prefabs/ScoreSettlementUI/DeprecatedScoreSettlementPanel_prefab.bundle
@@ -668,7 +660,7 @@ MonoBehaviour:
     BundleIdentifyName: BundleRes/Scenes.bundle
     Group: Base
     IsRaw: 0
-    AssetsLength: 1363453
+    AssetsLength: 1367201
     CompressOption: 2
     EncryptOption: 1
     Assets:
@@ -677,7 +669,7 @@ MonoBehaviour:
     - Name: Assets/BundleRes/Scenes/Dark.unity
       Length: 57120
     - Name: Assets/BundleRes/Scenes/Warm.unity
-      Length: 59433
+      Length: 63181
   - DirectoryName: BundleRes
     BundleName: Scenes_res.bundle
     BundleIdentifyName: BundleRes/Scenes_res.bundle
@@ -2066,6 +2058,50 @@ MonoBehaviour:
     Assets:
     - Name: Assets/CysMultimediaAssets/Sprites/MapSelectionPanel/TrackStartButton.png
       Length: 53567
+  - DirectoryName: CysMultimediaAssets/Sprites/MusicGamePlay
+    BundleName: "\u6682\u505C\u6309\u94AE_png.bundle"
+    BundleIdentifyName: "CysMultimediaAssets/Sprites/MusicGamePlay/\u6682\u505C\u6309\u94AE_png.bundle"
+    Group: Base
+    IsRaw: 0
+    AssetsLength: 14772
+    CompressOption: 2
+    EncryptOption: 1
+    Assets:
+    - Name: "Assets/CysMultimediaAssets/Sprites/MusicGamePlay/\u6682\u505C\u6309\u94AE.png"
+      Length: 14772
+  - DirectoryName: CysMultimediaAssets/Sprites/MusicGamePlay
+    BundleName: "\u6682\u505C\u8986\u5C42_png.bundle"
+    BundleIdentifyName: "CysMultimediaAssets/Sprites/MusicGamePlay/\u6682\u505C\u8986\u5C42_png.bundle"
+    Group: Base
+    IsRaw: 0
+    AssetsLength: 945125
+    CompressOption: 2
+    EncryptOption: 1
+    Assets:
+    - Name: "Assets/CysMultimediaAssets/Sprites/MusicGamePlay/\u6682\u505C\u8986\u5C42.png"
+      Length: 945125
+  - DirectoryName: CysMultimediaAssets/Sprites/MusicGamePlay
+    BundleName: "\u6682\u505C\u8F68\u9053_png.bundle"
+    BundleIdentifyName: "CysMultimediaAssets/Sprites/MusicGamePlay/\u6682\u505C\u8F68\u9053_png.bundle"
+    Group: Base
+    IsRaw: 0
+    AssetsLength: 335357
+    CompressOption: 2
+    EncryptOption: 1
+    Assets:
+    - Name: "Assets/CysMultimediaAssets/Sprites/MusicGamePlay/\u6682\u505C\u8F68\u9053.png"
+      Length: 335357
+  - DirectoryName: CysMultimediaAssets/Sprites/MusicGamePlay
+    BundleName: "\u97F3\u6E38\u6682\u505C64px(27x30)_png.bundle"
+    BundleIdentifyName: "CysMultimediaAssets/Sprites/MusicGamePlay/\u97F3\u6E38\u6682\u505C64px(27x30)_png.bundle"
+    Group: Base
+    IsRaw: 0
+    AssetsLength: 3413
+    CompressOption: 2
+    EncryptOption: 1
+    Assets:
+    - Name: "Assets/CysMultimediaAssets/Sprites/MusicGamePlay/\u97F3\u6E38\u6682\u505C64px(27x30).png"
+      Length: 3413
   - DirectoryName: CysMultimediaAssets/Sprites
     BundleName: PauseButton_png.bundle
     BundleIdentifyName: CysMultimediaAssets/Sprites/PauseButton_png.bundle
@@ -2304,12 +2340,20 @@ MonoBehaviour:
     BundleIdentifyName: Redundancy_0.bundle
     Group: Base
     IsRaw: 0
-    AssetsLength: 430723
+    AssetsLength: 3055822
     CompressOption: 2
     EncryptOption: 1
     Assets:
+    - Name: Assets/TextMeshPro/Fonts/LiberationSans.ttf
+      Length: 350200
+    - Name: Assets/TextMeshPro/Resources/Fonts & Materials/LiberationSans SDF - Fallback.asset
+      Length: 9713
+    - Name: Assets/TextMeshPro/Resources/Fonts & Materials/LiberationSans SDF.asset
+      Length: 2256862
     - Name: Assets/TextMeshPro/Shaders/TMP_SDF.shader
       Length: 11353
+    - Name: Assets/TextMeshPro/Shaders/TMP_SDF-Mobile.shader
+      Length: 8324
     - Name: Packages/com.unity.render-pipelines.universal/Runtime/Materials/Lit.mat
       Length: 4123
     - Name: Packages/com.unity.render-pipelines.universal/Shaders/Lit.shader
@@ -2340,7 +2384,7 @@ MonoBehaviour:
       Length: 4659
     - Name: Packages/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesUnlit.shader
       Length: 12430
-  BundleCount: 184
-  AssetCount: 289
+  BundleCount: 188
+  AssetCount: 293
   IsExactTextureSize: 0
   IsDrawDesc: 0


### PR DESCRIPTION
暂时优化了音游和暂停 UI

Diff:

* 调整了默认摄像机角度和位置。
* 顶部进度条改为白色。
* 调整暂停按钮、连击数文本、分数文本、杂率文本的位置。
* 调整暂停按钮样式。
* 调整暂停面板样式。
* 移除了 3D 分数和杂率，同时移除了 3D 面板物体，改为 2D 文本，支持按照不同的状态动态显示颜色。

<img width="1022" height="471" alt="图片" src="https://github.com/user-attachments/assets/518279a9-e8f9-425e-a2e0-09171cfac6ab" />

<img width="1010" height="461" alt="图片" src="https://github.com/user-attachments/assets/871e1824-a9ef-4c34-a846-1ac314e23443" />
