### PR TITLE
Fix: 从制谱器退出时未全量加载谱包

### DIFF
--- a/Cyan-Stars/Assets/Scripts/Gameplay/Base/Procedure/MainHomeProcedure.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/Base/Procedure/MainHomeProcedure.cs
@@ -1,9 +1,7 @@
-﻿using CyanStars.Framework;
+﻿using CyanStars.Chart;
+using CyanStars.Framework;
 using CyanStars.Framework.FSM;
-using CyanStars.Framework.Timer;
-using CyanStars.Framework.UI;
 using CyanStars.Gameplay.MusicGame;
-using UnityEngine;
 
 namespace CyanStars.Gameplay.Base
 {
@@ -13,12 +11,10 @@ namespace CyanStars.Gameplay.Base
     [ProcedureState]
     public class MainHomeProcedure : BaseState
     {
-
-
         public override async void OnEnter()
         {
-            //打开谱面选择界面
-            await GameRoot.UI.OpenUIPanelAsync<MapSelectionPanel>();
+            await GameRoot.GetDataModule<ChartModule>().ReloadAllChartPacksAsync();
+            await GameRoot.UI.OpenUIPanelAsync<MapSelectionPanel>(); //打开谱面选择界面
         }
 
         public override void OnUpdate(float deltaTime)

--- a/Cyan-Stars/Assets/Scripts/Gameplay/Base/Procedure/StartupProcedure.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/Base/Procedure/StartupProcedure.cs
@@ -1,4 +1,3 @@
-using CyanStars.Chart;
 using CyanStars.Framework;
 using CyanStars.Framework.FSM;
 
@@ -10,23 +9,21 @@ namespace CyanStars.Gameplay.Base
     [ProcedureState(true)]
     public class StartupProcedure : BaseState
     {
-        public override async void OnEnter()
+        public override void OnEnter()
         {
 #if UNITY_EDITOR
             if (GameRoot.Asset.IsEditorMode)
             {
                 //编辑器下并且开启了编辑器资源模式 直接切换到主界面流程
-                await GameRoot.GetDataModule<ChartModule>().ReloadAllChartPacksAsync();
                 GameRoot.ChangeProcedure<MainHomeProcedure>();
                 return;
             }
 #endif
             //否则需要先检查资源清单
-            GameRoot.Asset.CheckVersion(async result =>
+            GameRoot.Asset.CheckVersion(result =>
             {
                 if (result.Success)
                 {
-                    await GameRoot.GetDataModule<ChartModule>().ReloadAllChartPacksAsync();
                     GameRoot.ChangeProcedure<MainHomeProcedure>();
                 }
             });

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MapSelection/MapListPage.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MapSelection/MapListPage.cs
@@ -169,6 +169,7 @@ namespace CyanStars.Gameplay.MusicGame
                 mapTitleText.DOFade(1, 0.2f);
             });
 
+            // 将原始 Staff 文本传递给 StarsGenerator 以进一步处理
             if (chartModule.SelectedMusicVersionIndex == null)
             {
                 Debug.LogWarning("没有设置音乐版本");
@@ -177,7 +178,15 @@ namespace CyanStars.Gameplay.MusicGame
 
             Dictionary<string, List<string>> staffs = mapItem.Data.RuntimeChartPack.ChartPackData
                 .MusicVersionDatas[(int)chartModule.SelectedMusicVersionIndex].Staffs;
-            owner.StarController.ResetAllStaffGroup(staffs);
+            if (staffs.Count == 0)
+            {
+                Debug.LogWarning("没有设置 Staff 文本");
+            }
+            else
+            {
+                owner.StarController.ResetAllStaffGroup(mapItem.Data.RuntimeChartPack.ChartPackData
+                    .MusicVersionDatas[(int)chartModule.SelectedMusicVersionIndex].Staffs);
+            }
         }
     }
 }

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MapSelection/MapListPage.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MapSelection/MapListPage.cs
@@ -35,7 +35,7 @@ namespace CyanStars.Gameplay.MusicGame
 
         private MusicGamePlayingDataModule musicGamePlayingDataModule;
         private ChartModule chartModule;
-        private List<BaseUIItem> mapItems;
+        private List<MapItem> mapItems;
 
 
         public void OnInit(MapSelectionPanel owner)
@@ -47,7 +47,7 @@ namespace CyanStars.Gameplay.MusicGame
 
             musicGamePlayingDataModule = GameRoot.GetDataModule<MusicGamePlayingDataModule>();
             chartModule = GameRoot.GetDataModule<ChartModule>();
-            mapItems = new List<BaseUIItem>();
+            mapItems = new List<MapItem>();
 
             mapTitleText.text = ""; // 防止编辑器内的示例标题参与首次打开 UI 时的淡出动画
             nextStepButton.onClick.AddListener(() =>
@@ -66,11 +66,10 @@ namespace CyanStars.Gameplay.MusicGame
             canvasGroup.alpha = 0;
             gameObject.SetActive(true);
 
-            if (mapItems.Count == 0)
-            {
-                circularMapList.ResetItems();
-                await RefreshMusicList();
-            }
+            ClearMapItems();
+            circularMapList.ResetItems();
+            await RefreshMusicList();
+
 
             OnSelectMap(mapItems[this.owner.CurrentSelectedMap.Index] as MapItem);
             runningTween = canvasGroup.DOFade(1, args.FadeTime)
@@ -99,8 +98,30 @@ namespace CyanStars.Gameplay.MusicGame
 
             runningTween = canvasGroup.DOFade(0, args.FadeTime)
                 .SetEase(args.AnimationEase)
-                .OnComplete(() => gameObject.SetActive(false))
+                .OnComplete(() =>
+                {
+                    ClearMapItems();
+                    gameObject.SetActive(false);
+                })
                 .OnKill(() => runningTween = null);
+        }
+
+        /// <summary>
+        /// 清理旧的谱面项，解绑事件并销毁/回收物体
+        /// </summary>
+        private void ClearMapItems()
+        {
+            if (mapItems == null)
+                return;
+
+            for (int i = mapItems.Count - 1; i >= 0; i--)
+            {
+                var item = mapItems[i];
+                item.OnSelect -= OnSelectMap;
+                GameRoot.UI.ReleaseUIItem(item);
+            }
+
+            mapItems.Clear();
         }
 
         /// <summary>

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MapSelection/MapSelectionPanel.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MapSelection/MapSelectionPanel.cs
@@ -35,12 +35,14 @@ namespace CyanStars.Gameplay.MusicGame
 
         protected override void OnCreate()
         {
-            // 进入选曲页时，如果没有选中谱包，自动选择第一个谱包
+            // 进入选曲页时，如果没有选中谱包，自动选择第一个谱包，如果下标越界则自动选择最后一个谱包
             // TODO: 在新建谱包进入制谱器时，此值可能为 null，后续考虑改为 bool 标记
             // TODO: 改为玩家上次选择的序号
             var chartModule = GameRoot.GetDataModule<ChartModule>();
             if (chartModule.SelectedChartPackIndex == null)
                 chartModule.SelectChartPackData(0);
+            if (chartModule.SelectedChartPackIndex >= chartModule.RuntimeChartPacks.Count)
+                chartModule.SelectChartPackData(chartModule.RuntimeChartPacks.Count - 1);
             CurrentSelectedMap =
                 MapItemData.Create((int)chartModule.SelectedChartPackIndex!, chartModule.SelectedRuntimeChartPack!);
 

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MapSelection/StarController.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MapSelection/StarController.cs
@@ -177,7 +177,7 @@ namespace CyanStars.Gameplay.MusicGame
         {
             if (groupCount == 0)
             {
-                Debug.LogWarning("Staff 为空或未调用 ResetAllStaffGroup 方法");
+                Debug.LogError("请先调用 ResetAllStaffGroup 方法");
                 return;
             }
 


### PR DESCRIPTION
目前进入制谱器用的是只加载一张谱包谱面的临时方案，导致从制谱器退出时依然只在 module 中保留了这一张谱包，其他谱包不会被加载

现在每次进入游戏和退出制谱器时做了个全量加载

应该会和 #375 有合并冲突