### PR TITLE
Fix: BpmItem 下标越界和显示异常

### DIFF
--- a/Cyan-Stars/Assets/BundleRes/Scenes/ChartEditor.unity
+++ b/Cyan-Stars/Assets/BundleRes/Scenes/ChartEditor.unity
@@ -7396,7 +7396,6 @@ GameObject:
   - component: {fileID: 475630458}
   - component: {fileID: 475630457}
   - component: {fileID: 475630456}
-  - component: {fileID: 475630460}
   m_Layer: 5
   m_Name: Content
   m_TagString: Untagged
@@ -7502,19 +7501,6 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
---- !u!114 &475630460
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 475630454}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2fafe2cfe61f6974895a912c3755e8f1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.ToggleGroup
-  m_AllowSwitchOff: 0
 --- !u!1001 &477594328
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10010,7 +9996,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::CyanStars.Gameplay.ChartEditor.View.BpmGroupView
   closeCanvasButton: {fileID: 584011670}
   bpmListItemPrefab: {fileID: 1084994031255308922, guid: a5036c9887aeb494f912cb0b7b23c632, type: 3}
-  bpmListToggleGroup: {fileID: 475630460}
+  bpmListToggleGroup: {fileID: 0}
   itemContentTransform: {fileID: 475630455}
   bpmGroupListGameObject: {fileID: 2075881149}
   addBpmItemButton: {fileID: 1372622811}

--- a/Cyan-Stars/Assets/Scripts/Chart/BpmGroupHelper.cs
+++ b/Cyan-Stars/Assets/Scripts/Chart/BpmGroupHelper.cs
@@ -106,7 +106,7 @@ namespace CyanStars.Chart
 
             if (status == BpmValidationStatus.Valid)
             {
-                Debug.LogWarning("列表已经有序了！");
+                Debug.Log("列表已经有序了！");
                 return; // 已经有序直接返回，避免触发 Change 事件
             }
             else if (status == BpmValidationStatus.Invalid)

--- a/Cyan-Stars/Assets/Scripts/Gameplay/ChartEditor/View/BpmGroupListItemView.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/ChartEditor/View/BpmGroupListItemView.cs
@@ -43,12 +43,12 @@ namespace CyanStars.Gameplay.ChartEditor.View
             itemNumberText.text = $"#{index + 1}";
             beatAndTimeText.text = GetDetailText(targetViewModel, index);
 
-            var selectableStateObserver = itemToggle.GetComponent<SelectableStateObserver>();
+            SelectableStateObserver? selectableStateObserver = itemToggle.GetComponent<SelectableStateObserver>();
             targetViewModel.SelectedBpmItemIndex
                 .Subscribe(i =>
                 {
                     itemToggle.SetIsOnWithoutNotify(i == index);
-                    selectableStateObserver.RefreshToggleIson();
+                    selectableStateObserver?.RefreshToggleIson();
                 })
                 .AddTo(disposables);
             targetViewModel.BpmGroupDataChangedSubject
@@ -61,6 +61,7 @@ namespace CyanStars.Gameplay.ChartEditor.View
                 })
                 .AddTo(disposables);
 
+            // TODO: 后续改为 RadioButton 控制 Toggle 状态
             itemToggle
                 .OnValueChangedAsObservable()
                 .Subscribe((targetViewModel, index, itemToggle, selectableStateObserver), static (isOn, state) =>

--- a/Cyan-Stars/Assets/Scripts/Gameplay/ChartEditor/View/BpmGroupListItemView.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/ChartEditor/View/BpmGroupListItemView.cs
@@ -2,6 +2,7 @@
 
 using CyanStars.Chart;
 using CyanStars.Gameplay.ChartEditor.ViewModel;
+using CyanStars.Utils.SelectableUI;
 using R3;
 using TMPro;
 using UnityEngine;
@@ -32,20 +33,23 @@ namespace CyanStars.Gameplay.ChartEditor.View
             itemToggle = GetComponent<Toggle>();
         }
 
-        public void Bind(BpmGroupViewModel targetViewModel, ToggleGroup bpmListToggleGroup, int index)
+        public void Bind(BpmGroupViewModel targetViewModel, int index)
         {
             destroyCancellationToken.ThrowIfCancellationRequested();
 
             TryReleaseBind();
             disposables = new CompositeDisposable();
 
-            itemToggle.group = bpmListToggleGroup;
-
             itemNumberText.text = $"#{index + 1}";
             beatAndTimeText.text = GetDetailText(targetViewModel, index);
 
+            var selectableStateObserver = itemToggle.GetComponent<SelectableStateObserver>();
             targetViewModel.SelectedBpmItemIndex
-                .Subscribe(i => itemToggle.isOn = i == index)
+                .Subscribe(i =>
+                {
+                    itemToggle.SetIsOnWithoutNotify(i == index);
+                    selectableStateObserver.RefreshToggleIson();
+                })
                 .AddTo(disposables);
             targetViewModel.BpmGroupDataChangedSubject
                 .Subscribe(changedItemIndex =>
@@ -59,10 +63,16 @@ namespace CyanStars.Gameplay.ChartEditor.View
 
             itemToggle
                 .OnValueChangedAsObservable()
-                .Subscribe((targetViewModel, index), static (isOn, state) =>
+                .Subscribe((targetViewModel, index, itemToggle, selectableStateObserver), static (isOn, state) =>
                 {
                     if (isOn)
                         state.targetViewModel.SelectBpmItem(state.targetViewModel.BpmItems[state.index]);
+                    else if (state.targetViewModel.SelectedBpmItemIndex.CurrentValue == state.index)
+                    {
+                        // 拦截用户的取消勾选
+                        state.itemToggle.SetIsOnWithoutNotify(true);
+                        state.selectableStateObserver.RefreshToggleIson();
+                    }
                 })
                 .AddTo(disposables);
         }
@@ -76,6 +86,9 @@ namespace CyanStars.Gameplay.ChartEditor.View
         {
             disposables?.Dispose();
             disposables = null;
+
+            itemToggle.group = null;
+            itemToggle.isOn = false;
         }
 
         private string GetDetailText(BpmGroupViewModel targetViewModel, int index)

--- a/Cyan-Stars/Assets/Scripts/Gameplay/ChartEditor/View/BpmGroupView.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/ChartEditor/View/BpmGroupView.cs
@@ -1,6 +1,8 @@
 ﻿#nullable enable
 
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using CyanStars.Gameplay.ChartEditor.ViewModel;
 using CyanStars.Utils.SelectableUI;
 using ObservableCollections;
@@ -16,9 +18,6 @@ namespace CyanStars.Gameplay.ChartEditor.View
         [Header("列表子 View")]
         [SerializeField]
         private GameObject bpmListItemPrefab = null!;
-
-        [SerializeField]
-        private ToggleGroup bpmListToggleGroup = null!;
 
         [SerializeField]
         private RectTransform itemContentTransform = null!;
@@ -66,7 +65,7 @@ namespace CyanStars.Gameplay.ChartEditor.View
 
 
         private ReadOnlyReactiveProperty<bool> listVisibility = null!;
-        private Stack<BpmGroupListItemView> disabledListItemViews = new Stack<BpmGroupListItemView>();
+        private Stack<BpmGroupListItemView> disabledListItemViews = new Stack<BpmGroupListItemView>(); // 当做对象池来用
         private SelectableStateObserver? deleteItemButtonSelectableStateObserver;
 
 
@@ -88,60 +87,25 @@ namespace CyanStars.Gameplay.ChartEditor.View
             for (int i = 0; i < ViewModel.BpmItems.Count; i++)
             {
                 var go = Instantiate(bpmListItemPrefab, itemContentTransform);
-                go.GetComponent<BpmGroupListItemView>().Bind(ViewModel, bpmListToggleGroup, i);
+                go.GetComponent<BpmGroupListItemView>().Bind(ViewModel, i);
                 go.transform.SetSiblingIndex(itemContentTransform.childCount - 2);
             }
 
-            ViewModel.BpmItems.ObserveAdd()
+            ViewModel.BpmItems.ObserveChanged()
                 .Subscribe(e =>
                 {
-                    var (go, itemView) = GetOrCreateItemView();
-                    itemView.Bind(ViewModel, bpmListToggleGroup, e.Index);
-                    go.transform.SetSiblingIndex(e.Index);
-                })
-                .AddTo(this);
-            ViewModel.BpmItems.ObserveRemove()
-                .Subscribe(e =>
-                {
-                    var itemToRemove = itemContentTransform.GetChild(e.Index);
-                    var itemView = itemToRemove.GetComponent<BpmGroupListItemView>();
-                    itemView.TryReleaseBind();
-                    disabledListItemViews.Push(itemView);
-                    itemToRemove.gameObject.SetActive(false);
-                })
-                .AddTo(this);
-            ViewModel.BpmItems.ObserveMove()
-                .Subscribe(e =>
-                {
-                    var itemToMove = itemContentTransform.GetChild(e.OldIndex);
-                    itemToMove.SetSiblingIndex(e.NewIndex);
-                    itemToMove.GetComponent<BpmGroupListItemView>().Bind(ViewModel, bpmListToggleGroup, e.NewIndex);
-                })
-                .AddTo(this);
-            ViewModel.BpmItems.ObserveReplace()
-                .Subscribe(e =>
-                {
-                    var trans = itemContentTransform.GetChild(e.Index);
-                    trans.GetComponent<BpmGroupListItemView>().Bind(ViewModel, bpmListToggleGroup, e.Index);
-                    trans.SetSiblingIndex(e.Index);
-                })
-                .AddTo(this);
-            ViewModel.BpmItems.ObserveReset()
-                .Subscribe(e =>
-                {
-                    for (int i = itemContentTransform.childCount - 2; i >= 0; i--)
-                    {
-                        var item = itemContentTransform.GetChild(i);
-                        disabledListItemViews.Push(item.GetComponent<BpmGroupListItemView>());
-                        item.gameObject.SetActive(false);
-                    }
-
-                    for (int i = 0; i < ViewModel.BpmItems.Count; i++)
-                    {
-                        var (go, item) = GetOrCreateItemView();
-                        item.Bind(ViewModel, bpmListToggleGroup, i);
-                        item.transform.SetSiblingIndex(itemContentTransform.childCount - 2);
-                    }
+                    // 将所有的 -1 视为不参与比较，然后从所有参与比较的数中取最小值，刷新其与其后的所有 index
+                    // 显然如果观察到列表变化，两者都小于 0 的情况是不可能的
+                    int index;
+                    if (e.OldStartingIndex >= 0 && e.NewStartingIndex >= 0)
+                        index = Math.Min(e.OldStartingIndex, e.NewStartingIndex);
+                    else if (e.OldStartingIndex >= 0 && e.NewStartingIndex < 0)
+                        index = e.OldStartingIndex;
+                    else if (e.OldStartingIndex < 0 && e.NewStartingIndex >= 0)
+                        index = e.NewStartingIndex;
+                    else
+                        throw new Exception("列表发生变化但变化 index 均小于 0。");
+                    RebuildBpmItemViews(index);
                 })
                 .AddTo(this);
 
@@ -153,7 +117,7 @@ namespace CyanStars.Gameplay.ChartEditor.View
                 .Subscribe(item =>
                 {
                     detailFrameGameObject.SetActive(item != null);
-                    bpmInputField.SetTextWithoutNotify(item?.Bpm.ToString());
+                    bpmInputField.SetTextWithoutNotify(item?.Bpm.ToString(CultureInfo.InvariantCulture));
                     startBeatField1.SetTextWithoutNotify(item?.StartBeat.IntegerPart.ToString());
                     startBeatField2.SetTextWithoutNotify(item?.StartBeat.Numerator.ToString());
                     startBeatField3.SetTextWithoutNotify(item?.StartBeat.Denominator.ToString());
@@ -224,6 +188,28 @@ namespace CyanStars.Gameplay.ChartEditor.View
             {
                 var go = Instantiate(bpmListItemPrefab, itemContentTransform);
                 return (go, go.GetComponent<BpmGroupListItemView>());
+            }
+        }
+
+        private void RebuildBpmItemViews(int afterIndex = 0)
+        {
+            // TODO: itemContentTransform 末尾有一个添加按钮，故 -2，考虑下次将所有 item 单独移到一个 Frame 内
+            for (int i = itemContentTransform.childCount - 2; i >= afterIndex; i--)
+            {
+                var item = itemContentTransform.GetChild(i);
+                if (!item.gameObject.activeSelf)
+                    continue;
+                var itemView = item.GetComponent<BpmGroupListItemView>();
+                itemView.TryReleaseBind();
+                disabledListItemViews.Push(item.GetComponent<BpmGroupListItemView>());
+                item.gameObject.SetActive(false);
+            }
+
+            for (int i = afterIndex; i < ViewModel.BpmItems.Count; i++)
+            {
+                var (go, item) = GetOrCreateItemView();
+                item.Bind(ViewModel, i);
+                item.transform.SetSiblingIndex(itemContentTransform.childCount - 2);
             }
         }
     }

--- a/Cyan-Stars/Assets/Scripts/Gameplay/ChartEditor/ViewModel/BpmGroupViewModel.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/ChartEditor/ViewModel/BpmGroupViewModel.cs
@@ -78,16 +78,10 @@ namespace CyanStars.Gameplay.ChartEditor.ViewModel
                     oldStartBeat.Denominator, out Beat newStartBeat))
                 throw new Exception("无法正确构建 Beat");
 
+            var newItem = new BpmGroupItem(oldBpm, newStartBeat);
             CommandStack.ExecuteCommand(
-                () =>
-                {
-                    Model.ChartPackData.CurrentValue.BpmGroup.Add(new BpmGroupItem(oldBpm, newStartBeat));
-                },
-                () =>
-                {
-                    int lastItemIndex = Model.ChartPackData.CurrentValue.BpmGroup.Count - 1;
-                    Model.ChartPackData.CurrentValue.BpmGroup.RemoveAt(lastItemIndex);
-                }
+                () => Model.ChartPackData.CurrentValue.BpmGroup.Add(newItem),
+                () => Model.ChartPackData.CurrentValue.BpmGroup.Remove(newItem)
             );
         }
 
@@ -117,13 +111,15 @@ namespace CyanStars.Gameplay.ChartEditor.ViewModel
                 {
                     selectedBpmItem.CurrentValue.Bpm = newBpm;
                     BpmGroupHelper.Sort(Model.ChartPackData.CurrentValue.BpmGroup);
-                    Model.BpmGroupDataChangedSubject.OnNext(itemIndex);
+                    int newIndex = Model.ChartPackData.CurrentValue.BpmGroup.IndexOf(selectedBpmItem.CurrentValue);
+                    Model.BpmGroupDataChangedSubject.OnNext(Math.Min(itemIndex, newIndex));
                 },
                 () =>
                 {
                     selectedBpmItem.CurrentValue.Bpm = oldBpm;
                     BpmGroupHelper.Sort(Model.ChartPackData.CurrentValue.BpmGroup);
-                    Model.BpmGroupDataChangedSubject.OnNext(itemIndex);
+                    int newIndex = Model.ChartPackData.CurrentValue.BpmGroup.IndexOf(selectedBpmItem.CurrentValue);
+                    Model.BpmGroupDataChangedSubject.OnNext(Math.Min(itemIndex, newIndex));
                 }
             );
         }
@@ -161,6 +157,7 @@ namespace CyanStars.Gameplay.ChartEditor.ViewModel
             List<BpmGroupItem> newList = new List<BpmGroupItem>(Model.ChartPackData.CurrentValue.BpmGroup);
             newList.Remove(SelectedBpmItem.CurrentValue);
             newList.Add(new BpmGroupItem(selectedBpmItem.CurrentValue.Bpm, newBeat));
+            BpmGroupHelper.Sort(newList);
             if (BpmGroupHelper.Validate(newList) == BpmGroupHelper.BpmValidationStatus.Invalid)
             {
                 // 强制纠正 UI 的详情面板属性
@@ -174,15 +171,17 @@ namespace CyanStars.Gameplay.ChartEditor.ViewModel
                 {
                     selectedBpmItem.CurrentValue.StartBeat = newBeat;
                     BpmGroupHelper.Sort(Model.ChartPackData.CurrentValue.BpmGroup);
-                    Model.BpmGroupDataChangedSubject.OnNext(itemIndex);
-                    selectedBpmItem.ForceNotify(); // 刷新当前选中的 item 的详情面板属性，如 Number
+                    int newIndex = Model.ChartPackData.CurrentValue.BpmGroup.IndexOf(selectedBpmItem.CurrentValue);
+                    Model.BpmGroupDataChangedSubject.OnNext(Math.Min(itemIndex, newIndex));
+                    selectedBpmItem.ForceNotify();
                 },
                 () =>
                 {
                     selectedBpmItem.CurrentValue.StartBeat = oldBeat;
                     BpmGroupHelper.Sort(Model.ChartPackData.CurrentValue.BpmGroup);
-                    Model.BpmGroupDataChangedSubject.OnNext(itemIndex);
-                    selectedBpmItem.ForceNotify(); // 刷新当前选中的 item 的详情面板属性，如 Number
+                    int newIndex = Model.ChartPackData.CurrentValue.BpmGroup.IndexOf(selectedBpmItem.CurrentValue);
+                    Model.BpmGroupDataChangedSubject.OnNext(Math.Min(itemIndex, newIndex));
+                    selectedBpmItem.ForceNotify();
                 }
             );
         }
@@ -204,8 +203,8 @@ namespace CyanStars.Gameplay.ChartEditor.ViewModel
             CommandStack.ExecuteCommand(
                 () =>
                 {
-                    Model.ChartPackData.CurrentValue.BpmGroup.RemoveAt(oldIndex);
                     selectedBpmItem.Value = null;
+                    Model.ChartPackData.CurrentValue.BpmGroup.RemoveAt(oldIndex);
                 },
                 () =>
                 {

--- a/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableStateObserver.cs
+++ b/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableStateObserver.cs
@@ -110,6 +110,16 @@ namespace CyanStars.Utils.SelectableUI
             EvaluateState();
         }
 
+        /// <summary>
+        /// 外界直接以 SetIsOnWithoutNotify() 修改 Toggle 时将无法收到监听，可手动调用此方法强制更新。
+        /// </summary>
+        public void RefreshToggleIson()
+        {
+            if (selectable is Toggle toggle)
+                isKeepSelected = toggle.isOn;
+            EvaluateState();
+        }
+
 
         protected override void OnCanvasGroupChanged()
         {

--- a/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableStateObserver.cs
+++ b/Cyan-Stars/Assets/Scripts/Utils/SelectableUI/SelectableStateObserver.cs
@@ -133,8 +133,13 @@ namespace CyanStars.Utils.SelectableUI
         /// <summary>
         /// 当 selectable 是 toggle 时，外界改变 toggle.isOn 时也会自动改变视觉效果
         /// </summary>
-        private void OnToggleValueChanged(bool value)
+        private void OnToggleValueChanged(bool _)
         {
+            bool value = false;
+
+            if (selectable is Toggle toggle) // 手动获取真实状态，以防被拦截修改时依然接收到错误的事件参数
+                value = toggle.isOn;
+
             if (isKeepSelected == value)
                 return;
             isKeepSelected = value;


### PR DESCRIPTION
- 手动接管了 Toggle isOn 逻辑并删除了 ToggleGroup ，避免 ToggleGroup 在撤销重做和删除时背地里搞成吨的魔法操作
- 撤销重做 Toggle 选中状态时采用了 SetIsOnWithoutNotify() 来避免再次将 isOn 变更添加到命令栈，因此在 SelectableStateObserver 中添加了一个 RefreshToggleIson 方法，用于绕过 isOn 原生事件强制刷新

Fix: #377 