### PR TITLE
Fix: 谱包简介输入框初始化时未正确设置高度

### DIFF
--- a/Cyan-Stars/Assets/BundleRes/Prefabs/ChartEditor/Button(PlayPauseButton).prefab
+++ b/Cyan-Stars/Assets/BundleRes/Prefabs/ChartEditor/Button(PlayPauseButton).prefab
@@ -124,21 +124,7 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 7757076495624774869, guid: 5a80a8497a848f7448e263506e7997b4, type: 3}
       insertIndex: -1
       addedObject: {fileID: 4370685878280601434}
-    - targetCorrespondingSourceObject: {fileID: 7757076495624774869, guid: 5a80a8497a848f7448e263506e7997b4, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 3734390384676065572}
   m_SourcePrefab: {fileID: 100100000, guid: 5a80a8497a848f7448e263506e7997b4, type: 3}
---- !u!114 &4029066605407247544 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2870093097978841429, guid: 5a80a8497a848f7448e263506e7997b4, type: 3}
-  m_PrefabInstance: {fileID: 1170514568282396141}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &8905915770024456504 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7757076495624774869, guid: 5a80a8497a848f7448e263506e7997b4, type: 3}
@@ -164,28 +150,3 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
---- !u!114 &3734390384676065572
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8905915770024456504}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6141ddfe2d0548e29402dd3b7dd62294, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: CyanStars::CyanStars.Gameplay.ChartEditor.PlayPauseButton
-  Button: {fileID: 8905915770024456519}
-  Image: {fileID: 4029066605407247544}
---- !u!114 &8905915770024456519 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7757076495624774826, guid: 5a80a8497a848f7448e263506e7997b4, type: 3}
-  m_PrefabInstance: {fileID: 1170514568282396141}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8905915770024456504}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 

--- a/Cyan-Stars/Assets/Scripts/Libraries/CatAsset/Resources/BundleBuildConfig.asset
+++ b/Cyan-Stars/Assets/Scripts/Libraries/CatAsset/Resources/BundleBuildConfig.asset
@@ -216,12 +216,12 @@ MonoBehaviour:
     BundleIdentifyName: BundleRes/Prefabs/ChartEditor/Button(PlayPauseButton)_prefab.bundle
     Group: Base
     IsRaw: 0
-    AssetsLength: 8296
+    AssetsLength: 6525
     CompressOption: 2
     EncryptOption: 1
     Assets:
     - Name: Assets/BundleRes/Prefabs/ChartEditor/Button(PlayPauseButton).prefab
-      Length: 8296
+      Length: 6525
   - DirectoryName: BundleRes/Prefabs/ChartEditor
     BundleName: Button(Speed Element)_prefab.bundle
     BundleIdentifyName: BundleRes/Prefabs/ChartEditor/Button(Speed Element)_prefab.bundle
@@ -559,12 +559,12 @@ MonoBehaviour:
     BundleIdentifyName: BundleRes/Prefabs/MapSelectionUI/MapSelectionPanel_prefab.bundle
     Group: Base
     IsRaw: 0
-    AssetsLength: 191060
+    AssetsLength: 197208
     CompressOption: 2
     EncryptOption: 1
     Assets:
     - Name: Assets/BundleRes/Prefabs/MapSelectionUI/MapSelectionPanel.prefab
-      Length: 191060
+      Length: 197208
   - DirectoryName: BundleRes/Prefabs/MapSelectionUI
     BundleName: StaffLabel_prefab.bundle
     BundleIdentifyName: BundleRes/Prefabs/MapSelectionUI/StaffLabel_prefab.bundle
@@ -958,14 +958,14 @@ MonoBehaviour:
     BundleIdentifyName: CysMultimediaAssets/Font/SourceHanSerifCN/Regular.bundle
     Group: Base
     IsRaw: 0
-    AssetsLength: 49267740
+    AssetsLength: 49268331
     CompressOption: 2
     EncryptOption: 1
     Assets:
     - Name: Assets/CysMultimediaAssets/Font/SourceHanSerifCN/Regular/SourceHanSerifCN-Regular.otf
       Length: 11626108
     - Name: Assets/CysMultimediaAssets/Font/SourceHanSerifCN/Regular/SourceHanSerifCN-Regular-Dynamic-SDF.asset
-      Length: 2124157
+      Length: 2124748
     - Name: Assets/CysMultimediaAssets/Font/SourceHanSerifCN/Regular/SourceHanSerifCN-Regular-Static-3500Chinese-SDF(FastPacking).asset
       Length: 35517475
   - DirectoryName: CysMultimediaAssets/Font/SourceHanSerifCN

--- a/Cyan-Stars/Assets/Scripts/Utils/InputFieldRefreshHelper.cs
+++ b/Cyan-Stars/Assets/Scripts/Utils/InputFieldRefreshHelper.cs
@@ -72,7 +72,7 @@ namespace CyanStars
             textHeight += verticalPadding;
 
             float newHeight = Mathf.Max(layoutElement.minHeight, textHeight);
-            
+
             if (Mathf.Abs(layoutElement.preferredHeight - newHeight) > 0.1f)
                 layoutElement.preferredHeight = newHeight;
         }

--- a/Cyan-Stars/Assets/Scripts/Utils/InputFieldRefreshHelper.cs
+++ b/Cyan-Stars/Assets/Scripts/Utils/InputFieldRefreshHelper.cs
@@ -2,6 +2,7 @@
 
 using TMPro;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
 namespace CyanStars
@@ -11,7 +12,7 @@ namespace CyanStars
     /// </summary>
     [RequireComponent(typeof(TMP_InputField))]
     [RequireComponent(typeof(LayoutElement))]
-    public class InputFieldRefreshHelper : MonoBehaviour
+    public class InputFieldRefreshHelper : UIBehaviour
     {
         [SerializeField]
         private float verticalPadding = 30f;
@@ -19,28 +20,61 @@ namespace CyanStars
         private TMP_InputField tmpInputField = null!;
         private LayoutElement layoutElement = null!;
 
-        private void Awake()
+        protected override void Awake()
         {
+            base.Awake();
             tmpInputField = GetComponent<TMP_InputField>();
             layoutElement = GetComponent<LayoutElement>();
         }
 
-        private void Start() => CalculateHight(tmpInputField.text); // 初始化调用一次
-
-        private void OnEnable() => tmpInputField.onValueChanged.AddListener(CalculateHight);
-        private void OnDisable() => tmpInputField.onValueChanged.RemoveListener(CalculateHight);
-
-        private void CalculateHight(string text)
+        protected override void Start()
         {
+            base.Start();
+            CalculateHeight(tmpInputField.text); // 初始化调用一次
+        }
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            tmpInputField.onValueChanged.AddListener(CalculateHeight);
+        }
+
+        protected override void OnDisable()
+        {
+            base.OnDisable();
+            tmpInputField.onValueChanged.RemoveListener(CalculateHeight);
+        }
+
+
+        protected override void OnRectTransformDimensionsChange()
+        {
+            base.OnRectTransformDimensionsChange();
+
+            if (tmpInputField != null && isActiveAndEnabled)
+            {
+                CalculateHeight(tmpInputField.text);
+            }
+        }
+
+
+        private void CalculateHeight(string text)
+        {
+            float textWidth = tmpInputField.textComponent.rectTransform.rect.width;
+            if (textWidth <= 0.01f)
+                return; // TMP 输入框尚未完成初始化
+
             // 末尾是换行符和空格等不可见字符的情况时，临时追加一个字符用于高度计算。
             string calcText = text;
             if (calcText.EndsWith("\n") || calcText.EndsWith(" "))
                 calcText += ".";
 
-            float textWidth = tmpInputField.textComponent.rectTransform.rect.width;
             float textHeight = tmpInputField.textComponent.GetPreferredValues(calcText, textWidth, 0).y;
             textHeight += verticalPadding;
-            layoutElement.preferredHeight = Mathf.Max(layoutElement.minHeight, textHeight);
+
+            float newHeight = Mathf.Max(layoutElement.minHeight, textHeight);
+            
+            if (Mathf.Abs(layoutElement.preferredHeight - newHeight) > 0.1f)
+                layoutElement.preferredHeight = newHeight;
         }
     }
 }


### PR DESCRIPTION
制谱器场景初始化时，谱包简介输入框物体尚未初始化就进行了计算，导致高度错误。现在加了一步在 OnRectTransformDimensionsChange 后再次计算高度。