### PR TITLE
fix: rework markdown AtParagraph parser for support more cases

### DIFF
--- a/Cyan-Stars/Assets/Scripts/Libraries/MarkdownRenderer/Runtime/Extensions/AtParagraph/AtParagraphInline.cs
+++ b/Cyan-Stars/Assets/Scripts/Libraries/MarkdownRenderer/Runtime/Extensions/AtParagraph/AtParagraphInline.cs
@@ -4,13 +4,6 @@ namespace CyanStars.MarkdownRenderer.Extensions.AtParagraph
 {
     public sealed class AtParagraphInline : LinkInline
     {
-        public AtParagraphInline(string paragraph)
-        {
-            Paragraph = paragraph;
-            Label = "@" + paragraph;
-            Url = string.Empty;
-        }
-
-        public string Paragraph { get; }
+        public string Paragraph {get; set;}
     }
 }

--- a/Cyan-Stars/Assets/Scripts/Libraries/MarkdownRenderer/Runtime/Extensions/AtParagraph/AtParagraphInlineParser.cs
+++ b/Cyan-Stars/Assets/Scripts/Libraries/MarkdownRenderer/Runtime/Extensions/AtParagraph/AtParagraphInlineParser.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using Markdig.Helpers;
 using Markdig.Parsers;
 using Markdig.Syntax;
@@ -14,43 +16,94 @@ namespace CyanStars.MarkdownRenderer.Extensions.AtParagraph
 
         public override bool Match(InlineProcessor processor, ref StringSlice slice)
         {
-            var start = slice.Start;
-            if (slice.CurrentChar != '[' || slice.PeekChar() != '@')
+            var copied = slice;
+            if (InternalMatch(processor, ref copied))
+            {
+                slice = copied;
+                return true;
+            }
+            return false;
+        }
+
+        private bool InternalMatch(InlineProcessor processor, ref StringSlice slice)
+        {
+            int openingBracketIndex = slice.Start;
+
+            if (slice.PeekCharExtra(1) != '@' ||
+                !LinkHelper.TryParseLabel(ref slice, out string? label, out SourceSpan labelSpan) ||
+                label.Length <= 1)
             {
                 return false;
             }
 
-            var closingBracketIndex = slice.Text.IndexOf(']', start + 2, slice.End - start - 1);
-            if (closingBracketIndex < 0 || closingBracketIndex == start + 2 ||
-                (closingBracketIndex < slice.End && (slice.Text[closingBracketIndex + 1] == '(' || slice.Text[closingBracketIndex + 1] == '[')))
+            var saved = slice;
+            if (slice.CurrentChar == '(' &&
+                LinkHelper.TryParseInlineLink(ref slice, out _, out _, out _, out _))
             {
                 return false;
             }
 
-            var paragraph = slice.Text.Substring(start + 2, closingBracketIndex - start - 2);
-            var sourceStart = processor.GetSourcePosition(start, out var line, out var column);
-            var sourceEnd = processor.GetSourcePosition(closingBracketIndex);
-            var labelStart = processor.GetSourcePosition(start + 1);
-
-            var inline = new AtParagraphInline(paragraph)
+            slice = saved;
+            if (IsStandardReferenceLink(processor, ref slice, label))
             {
-                IsClosed = true,
-                Span = new SourceSpan(sourceStart, sourceEnd),
+                return false;
+            }
+
+            slice = saved;
+            processor.GetSourcePosition(openingBracketIndex, out int line, out int column);
+            int endPosition = slice.Start - 1;
+
+            var inline = new AtParagraphInline
+            {
+                Label = label,
+                Paragraph = label.Substring(1),
+                Span = new SourceSpan(
+                    processor.GetSourcePosition(openingBracketIndex),
+                    processor.GetSourcePosition(endPosition)),
                 Line = line,
                 Column = column,
+                IsClosed = true,
             };
+
             inline.AppendChild(new LiteralInline
             {
-                Content = new StringSlice(slice.Text, start + 1, closingBracketIndex - 1),
-                IsClosed = true,
-                Span = new SourceSpan(labelStart, sourceEnd - 1),
+                Content = new StringSlice(label),
+                Span = new SourceSpan(
+                    processor.GetSourcePosition(labelSpan.Start),
+                    processor.GetSourcePosition(labelSpan.End)),
                 Line = line,
                 Column = column + 1,
+                IsClosed = true,
             });
 
-            slice.Start = closingBracketIndex + 1;
             processor.Inline = inline;
             return true;
+        }
+
+        private static bool IsStandardReferenceLink(InlineProcessor processor, ref StringSlice slice, string label)
+        {
+            if (slice.CurrentChar != '[')
+            {
+                return processor.Document.ContainsLinkReferenceDefinition(label);
+            }
+
+            var referenceSlice = slice;
+            if (!LinkHelper.TryParseLabel(ref referenceSlice, true, out string? referenceLabel, out _))
+            {
+                return processor.Document.ContainsLinkReferenceDefinition(label);
+            }
+
+            if (string.IsNullOrEmpty(referenceLabel))
+            {
+                return processor.Document.ContainsLinkReferenceDefinition(label);
+            }
+
+            if (processor.Document.ContainsLinkReferenceDefinition(referenceLabel))
+            {
+                return true;
+            }
+
+            return referenceLabel[0] != '@';
         }
     }
 }

--- a/Cyan-Stars/Assets/Scripts/Libraries/MarkdownRenderer/Tests/AtParagraphParseTests.cs
+++ b/Cyan-Stars/Assets/Scripts/Libraries/MarkdownRenderer/Tests/AtParagraphParseTests.cs
@@ -1,0 +1,82 @@
+using System.Linq;
+using CyanStars.MarkdownRenderer.Extensions.AtParagraph;
+using Markdig;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+using NUnit.Framework;
+
+namespace CyanStars.MarkdownRenderer.Tests
+{
+    public class AtParagraphParseTests
+    {
+        private MarkdownPipeline pipeline;
+
+        [SetUp]
+        public void Setup()
+        {
+            var builder = new MarkdownPipelineBuilder();
+            builder.Extensions.Add(new AtParagraphExtension());
+            pipeline = builder.Build();
+        }
+
+        [TestCase("[@test]", "@test")]
+        [TestCase("[@test\nnewline]", "@test newline")]
+        [TestCase(@"[@test \[ \]]", "@test [ ]")]
+        public void Should_Parse_Only_AtParagraph_Inline(string text, string expectedLabel)
+        {
+            var markdownText = text;
+            var document = Markdown.Parse(markdownText, pipeline);
+            var inlines = document.Descendants<AtParagraphInline>().ToArray();
+            Assert.IsNotNull(inlines);
+            Assert.AreEqual(1, inlines.Length);
+            var inline = inlines[0];
+            Assert.AreEqual(expectedLabel, inline.Label);
+            Assert.AreEqual(expectedLabel!.Substring(1), inline.Paragraph);
+        }
+
+        [Test]
+        public void Should_Parse_Multiple_AtParagraph_Inlines()
+        {
+            var markdownText = "[@test1]\n[@test2]";
+            var document = Markdown.Parse(markdownText, pipeline);
+            var inlines = document.Descendants<AtParagraphInline>().ToArray();
+            Assert.IsNotNull(inlines);
+            Assert.AreEqual(2, inlines.Length);
+            Assert.AreEqual("@test1", inlines[0].Label);
+            Assert.AreEqual("@test2", inlines[1].Label);
+        }
+
+        [Test]
+        public void Should_Parse_Multiple_AtParagraph_Inlines_Without_Delimiter()
+        {
+            var markdownText = "[@test1][@test2][@test3]";
+            var document = Markdown.Parse(markdownText, pipeline);
+            var inlines = document.Descendants<AtParagraphInline>().ToArray();
+            Assert.IsNotNull(inlines);
+            Assert.AreEqual(3, inlines.Length);
+            Assert.AreEqual("@test1", inlines[0].Label);
+            Assert.AreEqual("@test2", inlines[1].Label);
+            Assert.AreEqual("@test3", inlines[2].Label);
+        }
+
+        [Test]
+        public void Should_Skip_LinkInline_When_Parse_Multiple_Maybe_Matched_Inlines()
+        {
+            var markdownText = "[@test1]\n[@test2][@link]()\n[@test3]";
+            var document = Markdown.Parse(markdownText, pipeline);
+            var inlines = document.Descendants<AtParagraphInline>().ToArray();
+            Assert.IsNotNull(inlines);
+            Assert.AreEqual(3, inlines.Length);
+            Assert.AreEqual("@test1", inlines[0].Label);
+            Assert.AreEqual("@test2", inlines[1].Label);
+            Assert.AreEqual("@test3", inlines[2].Label);
+
+            var linkInlines = document.Descendants<LinkInline>()
+                                                .Where(x => x is not AtParagraphInline)
+                                                .ToArray();
+            Assert.IsNotNull(linkInlines);
+            Assert.AreEqual(1, linkInlines.Length);
+            Assert.AreEqual("@link", ((LiteralInline)linkInlines[0].FirstChild)!.Content.ToString());
+        }
+    }
+}

--- a/Cyan-Stars/Assets/Scripts/Libraries/MarkdownRenderer/Tests/AtParagraphParseTests.cs.meta
+++ b/Cyan-Stars/Assets/Scripts/Libraries/MarkdownRenderer/Tests/AtParagraphParseTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9727dbff6209adbe7a6c68de3c1b3090

--- a/Cyan-Stars/Assets/Scripts/Libraries/MarkdownRenderer/Tests/CyanStars.MarkdownRenderer.Tests.asmdef
+++ b/Cyan-Stars/Assets/Scripts/Libraries/MarkdownRenderer/Tests/CyanStars.MarkdownRenderer.Tests.asmdef
@@ -2,15 +2,24 @@
     "name": "CyanStars.MarkdownRenderer.Tests",
     "rootNamespace": "CyanStars.MarkdownRenderer.Tests",
     "references": [
-        "CyanStars.MarkdownRenderer"
+        "CyanStars.MarkdownRenderer",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll",
+        "Markdig.dll"
+    ],
     "autoReferenced": false,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
     "versionDefines": [],
     "noEngineReferences": false
 }


### PR DESCRIPTION
规避所有 link 语法规范的函数由 gpt 编写