### PR TITLE
enhanced: 迭代游戏内 tmp markdown

### DIFF
--- a/Cyan-Stars/Assets/BundleRes/Prefabs/MapSelectionUI/MapSelectionPanel.prefab
+++ b/Cyan-Stars/Assets/BundleRes/Prefabs/MapSelectionUI/MapSelectionPanel.prefab
@@ -5126,6 +5126,7 @@ GameObject:
   - component: {fileID: 8091976741325756718}
   - component: {fileID: 7743512686469982888}
   - component: {fileID: 376816032822809734}
+  - component: {fileID: 2141244312871611626}
   m_Layer: 5
   m_Name: "\u8BE6\u60C5Text (TMP)"
   m_TagString: Untagged
@@ -5309,6 +5310,21 @@ MonoBehaviour:
     QuoteSpacing: 0.5
     BlockFakeMarginBottom: 0.5
     FinishBlockBehavior: 1
+--- !u!114 &2141244312871611626
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8282228296818145593}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f7c9f0f9c3d44d83a0cc5473699e333d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: CyanStars::CyanStars.Utils.TMPLinkHandler
+  openUrlPrefixes:
+  - __md_link__
+  fallbackAction: 0
 --- !u!1 &8526230953276327969
 GameObject:
   m_ObjectHideFlags: 0

--- a/Cyan-Stars/Assets/BundleRes/Prefabs/MapSelectionUI/MapSelectionPanel.prefab
+++ b/Cyan-Stars/Assets/BundleRes/Prefabs/MapSelectionUI/MapSelectionPanel.prefab
@@ -5322,7 +5322,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f7c9f0f9c3d44d83a0cc5473699e333d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: CyanStars::CyanStars.Utils.TMPLinkHandler
-  openUrlPrefixes:
+  openHttpUrlPrefixes:
   - __md_link__
   fallbackAction: 0
 --- !u!1 &8526230953276327969

--- a/Cyan-Stars/Assets/BundleRes/Prefabs/MapSelectionUI/MapSelectionPanel.prefab
+++ b/Cyan-Stars/Assets/BundleRes/Prefabs/MapSelectionUI/MapSelectionPanel.prefab
@@ -745,7 +745,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: CyanStars::CyanStars.ChartPackInfoPopup
   closePopupButton: {fileID: 1728638455343452706}
-  infoText: {fileID: 3142578377831822314}
+  infoTMPMarkdown: {fileID: 7743512686469982888}
 --- !u!1 &1272817708106903581
 GameObject:
   m_ObjectHideFlags: 0
@@ -5124,6 +5124,8 @@ GameObject:
   - component: {fileID: 2609384462153040281}
   - component: {fileID: 3142578377831822314}
   - component: {fileID: 8091976741325756718}
+  - component: {fileID: 7743512686469982888}
+  - component: {fileID: 376816032822809734}
   m_Layer: 5
   m_Name: "\u8BE6\u60C5Text (TMP)"
   m_TagString: Untagged
@@ -5264,6 +5266,49 @@ MonoBehaviour:
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.ContentSizeFitter
   m_HorizontalFit: 0
   m_VerticalFit: 2
+--- !u!114 &7743512686469982888
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8282228296818145593}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb6290c451a5b3a4b956eebaeba56c51, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: CyanStars.MarkdownRenderer::CyanStars.MarkdownRenderer.TextMeshProMarkdown
+  text: 
+  configProvider:
+    value: {fileID: 376816032822809734}
+  onDocumentParsed:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &376816032822809734
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8282228296818145593}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 113584774ebb6f27aa836f931023d9cf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: CyanStars.MarkdownRenderer::CyanStars.MarkdownRenderer.TextMeshProMarkdownConfigBehaviour
+  config:
+    CodeBlockBackgroundColor: {r: 0.533, g: 0.533, b: 0.533, a: 0.87}
+    AtColor: {r: 0.95686275, g: 0.77254903, b: 0.29803923, a: 0.87}
+    LinkColor: {r: 0.11372549, g: 0.54901963, b: 0.92941177, a: 0.87}
+    QuoteColor: {r: 0.6, g: 0.6, b: 0.6, a: 0.87}
+    LinkPrefix: __md_link__
+    UnorderedListMarker: "\xB7"
+    UnorderedListMarkerWidth: 0.5
+    NestingIndent: 1
+    QuoteBlockMargin: 0
+    QuoteSpacing: 0.5
+    BlockFakeMarginBottom: 0.5
+    FinishBlockBehavior: 1
 --- !u!1 &8526230953276327969
 GameObject:
   m_ObjectHideFlags: 0

--- a/Cyan-Stars/Assets/BundleRes/Scenes/ChartEditor.unity
+++ b/Cyan-Stars/Assets/BundleRes/Scenes/ChartEditor.unity
@@ -29306,7 +29306,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f7c9f0f9c3d44d83a0cc5473699e333d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: CyanStars::CyanStars.Utils.TMPLinkHandler
-  openUrlPrefixes:
+  openHttpUrlPrefixes:
   - __md_link__
   fallbackAction: 0
 --- !u!1 &1491843468

--- a/Cyan-Stars/Assets/BundleRes/Scenes/ChartEditor.unity
+++ b/Cyan-Stars/Assets/BundleRes/Scenes/ChartEditor.unity
@@ -29105,6 +29105,7 @@ GameObject:
   - component: {fileID: 1488809783}
   - component: {fileID: 1488809786}
   - component: {fileID: 1488809787}
+  - component: {fileID: 1488809788}
   m_Layer: 5
   m_Name: InfoPreviewText (TMP)
   m_TagString: Untagged
@@ -29293,6 +29294,21 @@ MonoBehaviour:
     QuoteSpacing: 0.5
     BlockFakeMarginBottom: 0.5
     FinishBlockBehavior: 1
+--- !u!114 &1488809788
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1488809781}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f7c9f0f9c3d44d83a0cc5473699e333d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: CyanStars::CyanStars.Utils.TMPLinkHandler
+  openUrlPrefixes:
+  - __md_link__
+  fallbackAction: 0
 --- !u!1 &1491843468
 GameObject:
   m_ObjectHideFlags: 0

--- a/Cyan-Stars/Assets/BundleRes/Scenes/ChartEditor.unity
+++ b/Cyan-Stars/Assets/BundleRes/Scenes/ChartEditor.unity
@@ -752,9 +752,9 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "\u53EF\u5728\u6B64\u586B\u5199\u4F5C\u54C1\u7B80\u4ECB\u3001\u97F3\u4E50\u521B\u4F5C\u56E2\u961F\u3001\u6F14\u5531\u8005\u3001\u8C31\u5E08\u3001\u6E38\u620F\u66F2\u7ED8\u4F5C\u8005\u7B49\u4FE1\u606F\uFF0C\u53EF\u4F7F\u7528
-    [@User Name] \u6807\u8BB0\u4F5C\u8005 ID\u3002\n\u540E\u7EED\u8FD8\u5C06\u652F\u6301
-    Markdown \u8BED\u6CD5\u3002"
+  m_text: "\u53EF\u5728\u6B64\u586B\u5199\u4F5C\u54C1\u7B80\u4ECB\u3001\u97F3\u4E50\u521B\u4F5C\u56E2\u961F\u3001\u6F14\u5531\u8005\u3001\u8C31\u5E08\u3001\u6E38\u620F\u66F2\u7ED8\u4F5C\u8005\u7B49\u4FE1\u606F\u3002\n\u652F\u6301
+    Markdown \u8BED\u6CD5\u3002\n\u53EF\u4F7F\u7528 [@User Name](https://example.com)
+    \u6807\u8BB0\u4F5C\u8005 ID \u548C\u4E3B\u9875\uFF0C\u5176\u4E2D\u4E3B\u9875\u5B57\u6BB5\u53EF\u7701\u7565\u3002"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: d17f214eb2e14e74c95fdc4e99b0187d, type: 2}
   m_sharedMaterial: {fileID: -7204877318828142287, guid: d17f214eb2e14e74c95fdc4e99b0187d, type: 2}
@@ -987,7 +987,7 @@ MonoBehaviour:
   coverPathText: {fileID: 1668466727}
   coverCropFrameObject: {fileID: 1514540014}
   infoInputField: {fileID: 318063048}
-  infoPreviewText: {fileID: 1488809783}
+  infoPreviewTMPMarkdown: {fileID: 1488809786}
   exportChartPackButton: {fileID: 1354379450}
 --- !u!1001 &43651018
 PrefabInstance:
@@ -12937,7 +12937,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 57909430}
   m_Direction: 2
   m_Value: 1
-  m_Size: 0.5651852
+  m_Size: 0.87777776
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -18152,10 +18152,6 @@ PrefabInstance:
     - target: {fileID: 994941279456320296, guid: 21018f88cf8fd3d468929538bb4e0c4a, type: 3}
       propertyPath: m_Name
       value: "\u8C31\u5305\u4FE1\u606F\u5F39\u7A97Canvas"
-      objectReference: {fileID: 0}
-    - target: {fileID: 994941279456320301, guid: 21018f88cf8fd3d468929538bb4e0c4a, type: 3}
-      propertyPath: m_Enabled
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 994941279456320303, guid: 21018f88cf8fd3d468929538bb4e0c4a, type: 3}
       propertyPath: m_Pivot.x
@@ -29105,8 +29101,10 @@ GameObject:
   m_Component:
   - component: {fileID: 1488809782}
   - component: {fileID: 1488809784}
-  - component: {fileID: 1488809783}
   - component: {fileID: 1488809785}
+  - component: {fileID: 1488809783}
+  - component: {fileID: 1488809786}
+  - component: {fileID: 1488809787}
   m_Layer: 5
   m_Name: InfoPreviewText (TMP)
   m_TagString: Untagged
@@ -29131,8 +29129,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 702.50006, y: -365.905}
-  m_SizeDelta: {x: 1205.0001, y: 182.33}
+  m_AnchoredPosition: {x: 702.50006, y: -358.47}
+  m_SizeDelta: {x: 1205.0001, y: 167.46}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1488809783
 MonoBehaviour:
@@ -29154,9 +29152,9 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "<size=+10>\u5728<b>\u4E0B\u9762</b>\u5BF9\u5185\u5BB9\u8FDB<b>\u6E32\u67D3\u9884\u89C8</b></size>\n\n
-    \xB7 \u4F5C\u66F2/\u7F16\u66F2\uFF1A<color=#66AAFF>@\u4F5C\u8005 1</color> <color=#66AAFF>@\u4F5C\u8005
-    2</color>\n \xB7 \u6DF7\u97F3\uFF1A<color=#66AAFF>@\u4F5C\u8005 3</color>"
+  m_text: "<size=200%>\u5728<b>\u4E0B\u9762</b>\u5BF9\u5185\u5BB9\u8FDB\u884C<b>\u6E32\u67D3\u9884\u89C8</b></size>\n<line-height=0.5em>\n</line-height>\u2011<indent=0.5em>\u4F5C\u66F2/\u7F16\u66F2\uFF1A<color=#FFD614DE><u>@\u4F5C\u8005
+    1</u></color> <color=#FFD614DE><u>@\u4F5C\u8005 2</u></color></indent>\n\u2011<indent=0.5em>\u6DF7\u97F3\uFF1A<color=#FFD614DE><u>@\u4F5C\u8005
+    3</u></color></indent>"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: d17f214eb2e14e74c95fdc4e99b0187d, type: 2}
   m_sharedMaterial: {fileID: -7204877318828142287, guid: d17f214eb2e14e74c95fdc4e99b0187d, type: 2}
@@ -29250,6 +29248,51 @@ MonoBehaviour:
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.ContentSizeFitter
   m_HorizontalFit: 0
   m_VerticalFit: 2
+--- !u!114 &1488809786
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1488809781}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb6290c451a5b3a4b956eebaeba56c51, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: CyanStars.MarkdownRenderer::CyanStars.MarkdownRenderer.TextMeshProMarkdown
+  text: "# \u5728**\u4E0B\u9762**\u5BF9\u5185\u5BB9\u8FDB\u884C**\u6E32\u67D3\u9884\u89C8**\n\n-
+    \u4F5C\u66F2/\u7F16\u66F2\uFF1A[@\u4F5C\u8005 1] [@\u4F5C\u8005 2]\n- \u6DF7\u97F3\uFF1A[@\u4F5C\u8005
+    3]"
+  configProvider:
+    value: {fileID: 1488809787}
+  onDocumentParsed:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1488809787
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1488809781}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 113584774ebb6f27aa836f931023d9cf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: CyanStars.MarkdownRenderer::CyanStars.MarkdownRenderer.TextMeshProMarkdownConfigBehaviour
+  config:
+    CodeBlockBackgroundColor: {r: 0.533, g: 0.533, b: 0.533, a: 0.87}
+    AtColor: {r: 0.95686275, g: 0.77254903, b: 0.29803923, a: 0.87}
+    LinkColor: {r: 0.11372549, g: 0.54901963, b: 0.92941177, a: 0.87}
+    QuoteColor: {r: 0.6, g: 0.6, b: 0.6, a: 0.87}
+    LinkPrefix: __md_link__
+    UnorderedListMarker: "\xB7"
+    UnorderedListMarkerWidth: 0.5
+    NestingIndent: 1
+    QuoteBlockMargin: 0
+    QuoteSpacing: 0.5
+    BlockFakeMarginBottom: 0.5
+    FinishBlockBehavior: 1
 --- !u!1 &1491843468
 GameObject:
   m_ObjectHideFlags: 0

--- a/Cyan-Stars/Assets/Scripts/Chart/ChartPackInfoHelper.cs
+++ b/Cyan-Stars/Assets/Scripts/Chart/ChartPackInfoHelper.cs
@@ -1,63 +1,61 @@
-﻿#nullable enable
-
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
-using UnityEngine;
-
-namespace CyanStars.Chart
-{
-    /// <summary>
-    /// 用于将 ChartPackInfo 解析为 TMP Text 或 Staffs 的静态工具类
-    /// </summary>
-    public static class ChartPackInfoHelper
-    {
-        private static readonly Color AtColor = new(1, 0.841f, 0.078f, 0.87f);
-        private static readonly string AtHexColor = ColorUtility.ToHtmlStringRGBA(AtColor);
-        private static readonly Regex AtRegex = new(@"\[@([^\]]+)\]", RegexOptions.Compiled); // [@User Name]
-
-        /// <summary>
-        /// 解析为带格式的 TMP Text
-        /// </summary>
-        public static string ToTmpText(string chartPackInfo)
-        {
-            if (string.IsNullOrEmpty(chartPackInfo))
-                return string.Empty;
-
-            string replacement = $"<color=#{AtHexColor}>@$1</color>";
-            chartPackInfo = AtRegex.Replace(chartPackInfo, replacement);
-
-            // TODO: 进行 Markdown 格式解析
-
-            return chartPackInfo;
-        }
-
-        /// <summary>
-        /// 解析 Staffs 并去重
-        /// </summary>
-        public static HashSet<string> ToStaffs(string chartPackInfo)
-        {
-            HashSet<string> staffSet = new();
-
-            if (string.IsNullOrEmpty(chartPackInfo))
-                return staffSet;
-
-            MatchCollection matches = AtRegex.Matches(chartPackInfo);
-            if (matches.Count == 0)
-                return staffSet;
-
-            foreach (Match match in matches)
-            {
-                if (match.Groups.Count <= 1)
-                    continue;
-
-                string staffName = match.Groups[1].Value.Trim();
-                if (!string.IsNullOrEmpty(staffName))
-                {
-                    staffSet.Add(staffName);
-                }
-            }
-
-            return staffSet;
-        }
-    }
-}
+﻿// #nullable enable
+//
+// using System.Collections.Generic;
+// using System.Text.RegularExpressions;
+// using UnityEngine;
+//
+// namespace CyanStars.Chart
+// {
+//     /// <summary>
+//     /// 用于将 ChartPackInfo 解析为 TMP Text 或 Staffs 的静态工具类
+//     /// </summary>
+//     public static class ChartPackInfoHelper
+//     {
+//         private static readonly Color AtColor = new(1, 0.841f, 0.078f, 0.87f);
+//         private static readonly string AtHexColor = ColorUtility.ToHtmlStringRGBA(AtColor);
+//         private static readonly Regex AtRegex = new(@"\[@([^\]]+)\]", RegexOptions.Compiled); // [@User Name]
+//
+//         /// <summary>
+//         /// 解析为带格式的 TMP Text
+//         /// </summary>
+//         public static string ToTmpText(string chartPackInfo)
+//         {
+//             if (string.IsNullOrEmpty(chartPackInfo))
+//                 return string.Empty;
+//
+//             string replacement = $"<color=#{AtHexColor}>@$1</color>";
+//             chartPackInfo = AtRegex.Replace(chartPackInfo, replacement);
+//
+//             return chartPackInfo;
+//         }
+//
+//         /// <summary>
+//         /// 解析 Staffs 并去重
+//         /// </summary>
+//         public static HashSet<string> ToStaffs(string chartPackInfo)
+//         {
+//             HashSet<string> staffSet = new();
+//
+//             if (string.IsNullOrEmpty(chartPackInfo))
+//                 return staffSet;
+//
+//             MatchCollection matches = AtRegex.Matches(chartPackInfo);
+//             if (matches.Count == 0)
+//                 return staffSet;
+//
+//             foreach (Match match in matches)
+//             {
+//                 if (match.Groups.Count <= 1)
+//                     continue;
+//
+//                 string staffName = match.Groups[1].Value.Trim();
+//                 if (!string.IsNullOrEmpty(staffName))
+//                 {
+//                     staffSet.Add(staffName);
+//                 }
+//             }
+//
+//             return staffSet;
+//         }
+//     }
+// }

--- a/Cyan-Stars/Assets/Scripts/CyanStars.asmdef
+++ b/Cyan-Stars/Assets/Scripts/CyanStars.asmdef
@@ -16,7 +16,8 @@
         "GUID:77221876cc6b8244180b96e320b1bcd4",
         "GUID:f02da9ca564ed54499f6f43d8249d415",
         "GUID:f7c3854fe92796b44ace45670f7ee36c",
-        "GUID:c685d05731421f64287ad6d13be5af0e"
+        "GUID:c685d05731421f64287ad6d13be5af0e",
+        "GUID:f86fff73e27070d2b9a01de1a73ed02f"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Cyan-Stars/Assets/Scripts/Gameplay/ChartEditor/View/ChartPackDataView.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/ChartEditor/View/ChartPackDataView.cs
@@ -2,6 +2,7 @@
 
 using CyanStars.Chart;
 using CyanStars.Gameplay.ChartEditor.ViewModel;
+using CyanStars.MarkdownRenderer;
 using R3;
 using TMPro;
 using UnityEngine;
@@ -43,7 +44,7 @@ namespace CyanStars.Gameplay.ChartEditor.View
         private TMP_InputField infoInputField = null!;
 
         [SerializeField]
-        private TMP_Text infoPreviewText = null!;
+        private TextMeshProMarkdown infoPreviewTMPMarkdown = null!;
 
         [SerializeField]
         private Button exportChartPackButton = null!;
@@ -104,8 +105,8 @@ namespace CyanStars.Gameplay.ChartEditor.View
             ViewModel.ChartPackInfo
                 .Subscribe(text =>
                 {
-                    infoPreviewText.gameObject.SetActive(!string.IsNullOrEmpty(text));
-                    infoPreviewText.text = ChartPackInfoHelper.ToTmpText(text);
+                    infoPreviewTMPMarkdown.gameObject.SetActive(!string.IsNullOrEmpty(text));
+                    infoPreviewTMPMarkdown.Text = text;
                 })
                 .AddTo(this);
 

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MapSelection/ChartPackInfoPopup.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MapSelection/ChartPackInfoPopup.cs
@@ -1,7 +1,6 @@
 #nullable enable
 
-using CyanStars.Chart;
-using TMPro;
+using CyanStars.MarkdownRenderer;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -13,9 +12,9 @@ namespace CyanStars
         private Button closePopupButton = null!;
 
         [SerializeField]
-        private TMP_Text infoText = null!;
+        private TextMeshProMarkdown infoTMPMarkdown = null!;
 
-        public void SetInfoRawText(string rawText) => infoText.text = ChartPackInfoHelper.ToTmpText(rawText);
+        public void SetInfoRawText(string rawText) => infoTMPMarkdown.Text = rawText;
 
         private void OnEnable() => closePopupButton.onClick.AddListener(ClosePopup);
         private void OnDisable() => closePopupButton.onClick.RemoveListener(ClosePopup);

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MapSelection/MapListPage.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MapSelection/MapListPage.cs
@@ -36,6 +36,8 @@ namespace CyanStars.Gameplay.MusicGame
         private ChartModule chartModule;
         private List<MapItem> mapItems;
 
+        private readonly HashSet<string> staffNames = new();
+
 
         public void OnInit(MapSelectionPanel owner)
         {
@@ -171,7 +173,7 @@ namespace CyanStars.Gameplay.MusicGame
             }
 
             string chartPackInfo = mapItem.Data.RuntimeChartPack.ChartPackData.ChartPackInfo;
-            HashSet<string> staffNames = new();
+            staffNames.Clear();
 
             foreach (AtInfo atInfo in MarkdownUtils.CollectCysAtInfo(chartPackInfo))
             {

--- a/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MapSelection/MapListPage.cs
+++ b/Cyan-Stars/Assets/Scripts/Gameplay/MusicGame/UI/MapSelection/MapListPage.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using CyanStars.Framework;
 using CyanStars.Chart;
+using CyanStars.MarkdownRenderer.Utils;
 using DG.Tweening;
 using TMPro;
 using UnityEngine;
@@ -170,7 +171,13 @@ namespace CyanStars.Gameplay.MusicGame
             }
 
             string chartPackInfo = mapItem.Data.RuntimeChartPack.ChartPackData.ChartPackInfo;
-            HashSet<string> staffNames = ChartPackInfoHelper.ToStaffs(chartPackInfo);
+            HashSet<string> staffNames = new();
+
+            foreach (AtInfo atInfo in MarkdownUtils.CollectCysAtInfo(chartPackInfo))
+            {
+                staffNames.Add(atInfo.Content);
+            }
+
             owner.StarController.ResetAllStaffGroup(staffNames);
         }
     }

--- a/Cyan-Stars/Assets/Scripts/Libraries/MarkdownRenderer/Runtime/TextMeshProMarkdown.cs
+++ b/Cyan-Stars/Assets/Scripts/Libraries/MarkdownRenderer/Runtime/TextMeshProMarkdown.cs
@@ -59,6 +59,7 @@ namespace CyanStars.MarkdownRenderer
         {
             base.OnEnable();
             isDirty = true;
+            BuildTextMeshProRichText();
         }
 
 #if UNITY_EDITOR
@@ -75,7 +76,7 @@ namespace CyanStars.MarkdownRenderer
             // 在编辑器环境下确保始终创建新 writer 对象，以防意外更改导致 renderer 状态残留
             var writer = new StringWriter(new StringBuilder(512));
             toTextMeshProRenderer ??= new TextMeshProRenderer(writer);
-            
+
             if (pipeline == null)
             {
                 var pipelineBuilder = new MarkdownPipelineBuilder().UseCjkFriendlyEmphasis();

--- a/Cyan-Stars/Assets/Scripts/Libraries/MarkdownRenderer/Runtime/TextMeshProMarkdown.cs
+++ b/Cyan-Stars/Assets/Scripts/Libraries/MarkdownRenderer/Runtime/TextMeshProMarkdown.cs
@@ -59,6 +59,8 @@ namespace CyanStars.MarkdownRenderer
         {
             base.OnEnable();
             isDirty = true;
+
+            // 在 OnEnable 时立即构建一次，避免启用后、Update 之前残留一帧上次的旧文本造成闪烁
             BuildTextMeshProRichText();
         }
 

--- a/Cyan-Stars/Assets/Scripts/Utils/TMPLinkHandler.cs
+++ b/Cyan-Stars/Assets/Scripts/Utils/TMPLinkHandler.cs
@@ -16,12 +16,12 @@ namespace CyanStars.Utils
         /// <summary>
         /// 不处理该链接。
         /// </summary>
-        Null,
+        None,
 
         /// <summary>
-        /// 把整个 link 参数作为 URL 在浏览器中打开。
+        /// 把整个 link 参数作为 Http/Https URL 在浏览器中打开。
         /// </summary>
-        OpenUrl
+        OpenHttpUrl
     }
 
     /// <summary>
@@ -33,11 +33,11 @@ namespace CyanStars.Utils
     {
         [SerializeField]
         [Tooltip("link 参数以列表中任意前缀开头时，剥离该前缀后把剩余内容作为 URL 在浏览器中打开；空项会被忽略。")]
-        private List<string> openUrlPrefixes = new();
+        private List<string> openHttpUrlPrefixes = new();
 
         [SerializeField]
         [Tooltip("link 参数未匹配任何前缀时的兜底行为。")]
-        private FallbackActionType fallbackAction = FallbackActionType.Null;
+        private FallbackActionType fallbackAction = FallbackActionType.None;
 
         private TextMeshProUGUI textComponent = null!;
 
@@ -68,13 +68,33 @@ namespace CyanStars.Utils
             if (matchedPrefix != null)
             {
                 string url = linkId.Substring(matchedPrefix.Length);
-                if (!string.IsNullOrWhiteSpace(url))
-                    Application.OpenURL(url);
+                if (!string.IsNullOrWhiteSpace(url) && IsHttpUrl(url, out string validUrl1))
+                    Application.OpenURL(validUrl1);
                 return;
             }
 
-            if (fallbackAction == FallbackActionType.OpenUrl)
-                Application.OpenURL(linkId);
+            if (fallbackAction == FallbackActionType.OpenHttpUrl && IsHttpUrl(linkId, out string validUrl2))
+                Application.OpenURL(validUrl2);
+        }
+
+        /// <summary>
+        /// 校验传入的 URL 是否为 http:// 或 https:// 形式，规范 url 前后与中间的空格，返回规范化的 url
+        /// </summary>
+        private static bool IsHttpUrl(string url, out string validUrl)
+        {
+            validUrl = string.Empty;
+
+            if (!Uri.TryCreate(url.Trim(), UriKind.Absolute, out Uri? uri) || uri == null)
+                return false;
+
+            if ((uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps) ||
+                string.IsNullOrEmpty(uri.Host))
+            {
+                return false;
+            }
+
+            validUrl = uri.AbsoluteUri; // 空格会变成 %20，前后空格被去掉
+            return true;
         }
 
         /// <summary>
@@ -84,7 +104,7 @@ namespace CyanStars.Utils
         {
             string? matchedPrefix = null;
 
-            foreach (string prefix in openUrlPrefixes)
+            foreach (string prefix in openHttpUrlPrefixes)
             {
                 if (string.IsNullOrEmpty(prefix))
                     continue;

--- a/Cyan-Stars/Assets/Scripts/Utils/TMPLinkHandler.cs
+++ b/Cyan-Stars/Assets/Scripts/Utils/TMPLinkHandler.cs
@@ -1,0 +1,102 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace CyanStars.Utils
+{
+    /// <summary>
+    /// link 参数未匹配任何前缀时的兜底行为。
+    /// </summary>
+    public enum FallbackActionType
+    {
+        /// <summary>
+        /// 不处理该链接。
+        /// </summary>
+        Null,
+
+        /// <summary>
+        /// 把整个 link 参数作为 URL 在浏览器中打开。
+        /// </summary>
+        OpenUrl
+    }
+
+    /// <summary>
+    /// 处理同一物体上 <see cref="TextMeshProUGUI"/> 中富文本 <c>&lt;link&gt;</c> 的点击事件。
+    /// </summary>
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(TextMeshProUGUI))]
+    public class TMPLinkHandler : MonoBehaviour, IPointerClickHandler
+    {
+        [SerializeField]
+        [Tooltip("link 参数以列表中任意前缀开头时，剥离该前缀后把剩余内容作为 URL 在浏览器中打开；空项会被忽略。")]
+        private List<string> openUrlPrefixes = new();
+
+        [SerializeField]
+        [Tooltip("link 参数未匹配任何前缀时的兜底行为。")]
+        private FallbackActionType fallbackAction = FallbackActionType.Null;
+
+        private TextMeshProUGUI textComponent = null!;
+
+
+        private void Awake()
+        {
+            textComponent = GetComponent<TextMeshProUGUI>();
+        }
+
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            int linkIndex = TMP_TextUtilities.FindIntersectingLink(
+                textComponent,
+                eventData.position,
+                eventData.pressEventCamera
+            );
+
+            if (linkIndex == -1)
+                return;
+
+            TMP_LinkInfo linkInfo = textComponent.textInfo.linkInfo[linkIndex];
+            HandleLink(linkInfo.GetLinkID());
+        }
+
+        private void HandleLink(string linkId)
+        {
+            string? matchedPrefix = FindLongestMatchingPrefix(linkId);
+            if (matchedPrefix != null)
+            {
+                string url = linkId.Substring(matchedPrefix.Length);
+                if (!string.IsNullOrWhiteSpace(url))
+                    Application.OpenURL(url);
+                return;
+            }
+
+            if (fallbackAction == FallbackActionType.OpenUrl)
+                Application.OpenURL(linkId);
+        }
+
+        /// <summary>
+        /// 获取最长的匹配
+        /// </summary>
+        private string? FindLongestMatchingPrefix(string linkId)
+        {
+            string? matchedPrefix = null;
+
+            foreach (string prefix in openUrlPrefixes)
+            {
+                if (string.IsNullOrEmpty(prefix))
+                    continue;
+
+                if (!linkId.StartsWith(prefix, StringComparison.Ordinal))
+                    continue;
+
+                if (matchedPrefix == null || prefix.Length > matchedPrefix.Length)
+                    matchedPrefix = prefix;
+            }
+
+            return matchedPrefix;
+        }
+    }
+}

--- a/Cyan-Stars/Assets/Scripts/Utils/TMPLinkHandler.cs.meta
+++ b/Cyan-Stars/Assets/Scripts/Utils/TMPLinkHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f7c9f0f9c3d44d83a0cc5473699e333d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
将制谱器和选曲页内的谱包说明接入 TMP Markdown，同时实现了链接点击时打开 URL。

`Cyan-Stars/Assets/Scripts/Libraries/MarkdownRenderer/Runtime/TextMeshProMarkdown.cs` 现在会在 `OnEnable()` 时调用一次 `BuildTextMeshProRichText()`，以确保显示时字面正确。

## Berak Change

官方谱包和社区谱包需要检查和更新谱包说明字段。